### PR TITLE
fix: Correct PM2 restart command in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
           npm run build
           
           echo "🔄 Restarting application with PM2..."
-          pm2 restart targon-frontend
+          pm2 restart ecosystem.config.js
           
           echo "💾 Saving PM2 configuration..."
           pm2 save


### PR DESCRIPTION
The deployment was using 'pm2 restart targon-frontend' but should use 'pm2 restart ecosystem.config.js' to ensure it picks up the correct configuration including the right working directory.