### PR TITLE
ci: auto-sync dev to main

### DIFF
--- a/.github/workflows/auto-sync-dev.yml
+++ b/.github/workflows/auto-sync-dev.yml
@@ -1,0 +1,84 @@
+name: Auto Sync dev to main
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  sync-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure admin token is present
+        run: |
+          if [ -z "${{ secrets.ADMIN_TOKEN }}" ]; then
+            echo "ADMIN_TOKEN secret is not set. Create a classic PAT or fine-grained token with repo admin rights and add it as a repository secret named ADMIN_TOKEN." >&2
+            exit 1
+          fi
+
+      - name: Force-update dev to main HEAD and restore protections
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          REPO: ${{ github.repository }}
+          MAIN_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          branch=dev
+          api="https://api.github.com/repos/$REPO/branches/$branch/protection"
+
+          echo "Relaxing protection on $branch (allow force push; disable required checks)..."
+          curl -sS -X PUT \
+            -H "Authorization: token $ADMIN_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "$api" \
+            -d @- <<'JSON'
+          {
+            "required_status_checks": null,
+            "enforce_admins": true,
+            "required_pull_request_reviews": null,
+            "restrictions": null,
+            "required_linear_history": true,
+            "allow_force_pushes": true,
+            "allow_deletions": false,
+            "block_creations": false,
+            "required_conversation_resolution": false,
+            "lock_branch": false,
+            "allow_fork_syncing": false
+          }
+          JSON
+
+          echo "Pushing $MAIN_SHA to $branch (force)..."
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin
+          git push -f origin "$MAIN_SHA:refs/heads/$branch"
+
+          echo "Restoring protection on $branch (checks required; disallow force push)..."
+          curl -sS -X PUT \
+            -H "Authorization: token $ADMIN_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "$api" \
+            -d @- <<'JSON'
+          {
+            "required_status_checks": {
+              "strict": true,
+              "contexts": ["build-test", "GitGuardian Security Checks"]
+            },
+            "enforce_admins": true,
+            "required_pull_request_reviews": null,
+            "restrictions": null,
+            "required_linear_history": true,
+            "allow_force_pushes": false,
+            "allow_deletions": false,
+            "block_creations": false,
+            "required_conversation_resolution": false,
+            "lock_branch": false,
+            "allow_fork_syncing": false
+          }
+          JSON


### PR DESCRIPTION
Adds .github/workflows/auto-sync-dev.yml to mirror dev to main on every push to main. Requires repository secret ADMIN_TOKEN with admin permissions.\n\n- Temporarily relaxes dev protections\n- Force-updates dev to main SHA\n- Restores protections with required checks\n\nSOP: PR to dev first, then PR dev→main.