### PR TITLE
docs(branching): document feature → dev → main flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,4 @@
 - Group changes by app or shared package and mention additional workspaces touched when scopes differ.
 - PRs should include purpose, testing evidence (`pnpm lint && pnpm test`), screenshots for UI shifts, and linked GitHub issues.
 - Request owners of affected apps and shared packages as reviewers; flag infra updates for DevOps before merge.
+- Branching: use short-lived `feature/*` branches off `dev`, merge via PR with passing checks, and let automation fast-forward `main` from `dev`; never push directly to `main`.


### PR DESCRIPTION
## Summary
- note the required feature branch workflow in AGENTS.md
- remind contributors that  is updated only after merging to 

## Testing
- pnpm --filter @ecom-os/ecomos build
