### PR TITLE
auth(sso): unify dev session flow

### DIFF
--- a/apps/ecomos/app/login/login.css
+++ b/apps/ecomos/app/login/login.css
@@ -136,14 +136,35 @@
   font-size: 28px;
   font-weight: 700;
   color: #f1f5f9; /* slate-100 */
-  margin-bottom: 8px;
-  letter-spacing: -0.5px;
+  margin-bottom: 4px;
+  letter-spacing: -0.4px;
+}
+
+.login-headline {
+  font-size: 18px;
+  font-weight: 600;
+  color: #cbd5f5;
+  margin-bottom: 6px;
 }
 
 .login-subtitle {
   font-size: 15px;
   color: #94a3b8;
   font-weight: 400;
+}
+
+.form-global-error {
+  margin-bottom: 24px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(239, 68, 68, 0.12); /* red-500 at low opacity */
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  color: #fecaca; /* red-200 */
+  font-size: 14px;
+  line-height: 1.4;
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
 }
 
 .form-group {

--- a/apps/ecomos/app/login/page.tsx
+++ b/apps/ecomos/app/login/page.tsx
@@ -3,12 +3,27 @@
 import { useEffect, useState } from 'react'
 import './login.css'
 
-export default function LoginPage({ searchParams }: { searchParams?: { callbackUrl?: string } }) {
+export default function LoginPage({ searchParams }: { searchParams?: { callbackUrl?: string, error?: string } }) {
   const callbackUrl = searchParams?.callbackUrl || '/'
   const [csrfToken, setCsrfToken] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [formData, setFormData] = useState({ emailOrUsername: '', password: '' })
   const [errors, setErrors] = useState({ emailOrUsername: '', password: '' })
+  const [globalError, setGlobalError] = useState('')
+
+  useEffect(() => {
+    if (!searchParams?.error) {
+      setGlobalError('')
+      return
+    }
+    const code = searchParams.error
+    const friendly: Record<string, string> = {
+      CredentialsSignin: 'Invalid email or password. Please try again.',
+      AccessDenied: 'Your account does not have access. Contact an administrator.',
+      default: 'Unable to sign in right now. Please try again or reach out to support.',
+    }
+    setGlobalError(friendly[code] || friendly.default)
+  }, [searchParams?.error])
 
   useEffect(() => {
     let mounted = true
@@ -47,6 +62,9 @@ export default function LoginPage({ searchParams }: { searchParams?: { callbackU
       e.preventDefault()
       return
     }
+    if (globalError) {
+      setGlobalError('')
+    }
     setIsLoading(true)
   }
 
@@ -78,9 +96,16 @@ export default function LoginPage({ searchParams }: { searchParams?: { callbackU
                 </svg>
               </div>
             </div>
-            <h1 className="login-title">Welcome back</h1>
-            <p className="login-subtitle">Sign in to your ecomOS account</p>
+            <h1 className="login-title">ecomOS Portal</h1>
+            <p className="login-headline">Welcome back</p>
+            <p className="login-subtitle">Sign in to your account to launch connected apps</p>
           </div>
+
+          {globalError && (
+            <div className="form-global-error" role="alert">
+              {globalError}
+            </div>
+          )}
 
           <div className="form-group">
             <label htmlFor="emailOrUsername" className="form-label">

--- a/apps/ecomos/package.json
+++ b/apps/ecomos/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3000",
+    "dev": "node ../../scripts/run-dev-with-logs.js ecomos -- next dev -p 3000",
     "build": "next build",
     "start": "next start -p 3000",
     "type-check": "tsc --noEmit"

--- a/apps/ecomos/test-results/.last-run.json
+++ b/apps/ecomos/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/apps/ecomos/tests/login.spec.ts
+++ b/apps/ecomos/tests/login.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from '@playwright/test'
 
 const CENTRAL = 'http://localhost:3000'
 const WMS = 'http://localhost:3001'
-const DEMO_USERNAMES = ['demo-admin@warehouse.com']
-const DEMO_PASS = 'SecureWarehouse2024!'
+const DEMO_USERNAMES = ['jarraramjad']
+const DEMO_PASS = 'xUh2*KC2%tZYNzV'
 
 test('portal login redirects to portal home', async ({ page }) => {
   await page.goto(`${CENTRAL}/login`, { waitUntil: 'domcontentloaded' })

--- a/apps/fcc/lib/auth.ts
+++ b/apps/fcc/lib/auth.ts
@@ -1,12 +1,23 @@
 import type { NextAuthOptions } from 'next-auth'
-import { withSharedAuth } from '@ecom-os/auth'
+import { applyDevAuthDefaults, withSharedAuth } from '@ecom-os/auth'
+
+const devPort = process.env.PORT || process.env.FCC_PORT || 3003
+const devBaseUrl = process.env.NEXT_PUBLIC_APP_URL || `http://localhost:${devPort}`
+const centralDev = process.env.CENTRAL_AUTH_URL || 'http://localhost:3000'
+applyDevAuthDefaults({
+  appId: 'ecomos',
+  port: devPort,
+  baseUrl: devBaseUrl,
+  cookieDomain: 'localhost',
+  centralUrl: centralDev,
+  publicCentralUrl: process.env.NEXT_PUBLIC_CENTRAL_AUTH_URL || 'http://localhost:3000',
+})
 
 const baseAuthOptions: NextAuthOptions = {
   session: {
     strategy: 'jwt',
     maxAge: 30 * 24 * 60 * 60,
   },
-  secret: process.env.NEXTAUTH_SECRET,
   callbacks: {
     async jwt({ token, user }) {
       if (user && (user as any).id) {

--- a/apps/fcc/lib/auth.ts
+++ b/apps/fcc/lib/auth.ts
@@ -13,11 +13,17 @@ applyDevAuthDefaults({
   publicCentralUrl: process.env.NEXT_PUBLIC_CENTRAL_AUTH_URL || 'http://localhost:3000',
 })
 
+const sharedSecret = process.env.CENTRAL_AUTH_SECRET || process.env.NEXTAUTH_SECRET
+if (sharedSecret) {
+  process.env.NEXTAUTH_SECRET = sharedSecret
+}
+
 const baseAuthOptions: NextAuthOptions = {
   session: {
     strategy: 'jwt',
     maxAge: 30 * 24 * 60 * 60,
   },
+  secret: sharedSecret,
   callbacks: {
     async jwt({ token, user }) {
       if (user && (user as any).id) {

--- a/apps/fcc/middleware.ts
+++ b/apps/fcc/middleware.ts
@@ -144,7 +144,10 @@ export async function middleware(request: NextRequest) {
           { status: 401 }
         );
       }
-      const central = process.env.CENTRAL_AUTH_URL || 'https://ecomos.targonglobal.com'
+      const defaultCentral = process.env.NODE_ENV === 'production'
+        ? 'https://ecomos.targonglobal.com'
+        : 'http://localhost:3000'
+      const central = process.env.CENTRAL_AUTH_URL || defaultCentral
       const login = new URL('/login', central)
       login.searchParams.set('callbackUrl', request.nextUrl.toString())
       return NextResponse.redirect(login);

--- a/apps/fcc/middleware.ts
+++ b/apps/fcc/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { getToken } from 'next-auth/jwt';
+import { hasCentralSession } from '@ecom-os/auth';
 
 // Content Security Policy
 const CSP_DIRECTIVES = [
@@ -116,28 +116,18 @@ export async function middleware(request: NextRequest) {
       console.log(`[Middleware] Route ${pathname} requires authentication (isPublicRoute: ${isPublicRoute})`);
     }
     
-    // NextAuth session check via JWT cookie
-    let hasSession = false;
-    try {
-      const candidateNames = [
-        process.env.NODE_ENV === 'production'
-          ? '__Secure-next-auth.session-token'
-          : 'next-auth.session-token',
-        process.env.NODE_ENV === 'production'
-          ? '__Secure-next-auth.session-token'
-          : 'ecomos.next-auth.session-token',
-        // Legacy app-specific cookie during migration
-        process.env.NODE_ENV === 'production'
-          ? '__Secure-next-auth.session-token'
-          : 'fcc.next-auth.session-token',
-      ];
-      for (const name of candidateNames) {
-        const token = await getToken({ req: request as any, secret: process.env.NEXTAUTH_SECRET, cookieName: name });
-        if (token) { hasSession = true; break; }
-      }
-    } catch {}
+    const cookieNames = process.env.NODE_ENV === 'production'
+      ? ['__Secure-next-auth.session-token', '__Secure-fcc.next-auth.session-token']
+      : ['next-auth.session-token', 'ecomos.next-auth.session-token', 'fcc.next-auth.session-token'];
 
-    if (!hasSession && !devBypassSession) {
+    const hasSession = devBypassSession ? true : await hasCentralSession({
+      request: request as any,
+      cookieNames,
+      centralUrl: process.env.CENTRAL_AUTH_URL,
+      debug: process.env.NODE_ENV === 'development' && !pathname.includes('.'),
+    });
+
+    if (!hasSession) {
       if (pathname.startsWith('/api/')) {
         return NextResponse.json(
           { error: 'Unauthorized', message: 'Authentication required' },

--- a/apps/hrms/lib/auth.ts
+++ b/apps/hrms/lib/auth.ts
@@ -14,10 +14,16 @@ applyDevAuthDefaults({
   publicCentralUrl: process.env.NEXT_PUBLIC_CENTRAL_AUTH_URL || 'http://localhost:3000',
 });
 
+const sharedSecret = process.env.CENTRAL_AUTH_SECRET || process.env.NEXTAUTH_SECRET;
+if (sharedSecret) {
+  process.env.NEXTAUTH_SECRET = sharedSecret;
+}
+
 const baseAuthOptions: NextAuthOptions = {
   // Add providers when ready (e.g., Credentials, OIDC)
   providers: [],
   session: { strategy: 'jwt' },
+  secret: sharedSecret,
   callbacks: {
     async jwt({ token, user }) {
       if (user && (user as any).id) {

--- a/apps/hrms/lib/auth.ts
+++ b/apps/hrms/lib/auth.ts
@@ -1,7 +1,19 @@
 import type { NextAuthOptions } from 'next-auth';
-import { withSharedAuth } from '@ecom-os/auth';
+import { applyDevAuthDefaults, withSharedAuth } from '@ecom-os/auth';
 
 // NOTE: Keep providers/callbacks/pages here as HRMS evolves.
+const devPort = process.env.PORT || process.env.HRMS_PORT || 3006;
+const devBaseUrl = process.env.NEXT_PUBLIC_APP_URL || `http://localhost:${devPort}`;
+const centralDev = process.env.CENTRAL_AUTH_URL || 'http://localhost:3000';
+applyDevAuthDefaults({
+  appId: 'ecomos',
+  port: devPort,
+  baseUrl: devBaseUrl,
+  cookieDomain: 'localhost',
+  centralUrl: centralDev,
+  publicCentralUrl: process.env.NEXT_PUBLIC_CENTRAL_AUTH_URL || 'http://localhost:3000',
+});
+
 const baseAuthOptions: NextAuthOptions = {
   // Add providers when ready (e.g., Credentials, OIDC)
   providers: [],

--- a/apps/hrms/middleware.ts
+++ b/apps/hrms/middleware.ts
@@ -31,7 +31,10 @@ export async function middleware(request: NextRequest) {
     } catch {}
 
     if (!hasSession) {
-      const central = process.env.CENTRAL_AUTH_URL || 'https://ecomos.targonglobal.com'
+      const defaultCentral = process.env.NODE_ENV === 'production'
+        ? 'https://ecomos.targonglobal.com'
+        : 'http://localhost:3000'
+      const central = process.env.CENTRAL_AUTH_URL || defaultCentral
       const login = new URL('/login', central)
       login.searchParams.set('callbackUrl', request.nextUrl.toString())
       return NextResponse.redirect(login)
@@ -46,4 +49,3 @@ export const config = {
     '/((?!_next/static|_next/image|favicon.ico).*)',
   ],
 }
-

--- a/apps/hrms/middleware.ts
+++ b/apps/hrms/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
-import { getToken } from 'next-auth/jwt'
+import { hasCentralSession } from '@ecom-os/auth'
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
@@ -13,22 +13,13 @@ export async function middleware(request: NextRequest) {
     PUBLIC_PREFIXES.some((p) => pathname.startsWith(p))
 
   if (!isPublic) {
-    // Check central SSO cookie
-    let hasSession = false
-    try {
-      const candidateNames = [
-        process.env.NODE_ENV === 'production'
-          ? '__Secure-next-auth.session-token'
-          : 'next-auth.session-token',
-        process.env.NODE_ENV === 'production'
-          ? '__Secure-next-auth.session-token'
-          : 'ecomos.next-auth.session-token',
-      ]
-      for (const name of candidateNames) {
-        const token = await getToken({ req: request as any, secret: process.env.NEXTAUTH_SECRET, cookieName: name })
-        if (token) { hasSession = true; break }
-      }
-    } catch {}
+    const debug = process.env.NODE_ENV !== 'production'
+    const hasSession = await hasCentralSession({
+      request,
+      appId: 'ecomos',
+      centralUrl: process.env.CENTRAL_AUTH_URL,
+      debug,
+    })
 
     if (!hasSession) {
       const defaultCentral = process.env.NODE_ENV === 'production'
@@ -36,6 +27,9 @@ export async function middleware(request: NextRequest) {
         : 'http://localhost:3000'
       const central = process.env.CENTRAL_AUTH_URL || defaultCentral
       const login = new URL('/login', central)
+      if (debug) {
+        console.log('[hrms middleware] missing session, redirecting to', login.toString())
+      }
       login.searchParams.set('callbackUrl', request.nextUrl.toString())
       return NextResponse.redirect(login)
     }

--- a/apps/hrms/package.json
+++ b/apps/hrms/package.json
@@ -6,7 +6,7 @@
     "seed": "tsx prisma/seed.ts"
   },
   "scripts": {
-    "dev": "next dev -p 3006",
+    "dev": "node ../../scripts/run-dev-with-logs.js hrms -- next dev -p 3006",
     "build": "next build",
     "start": "next start -p 3006",
     "type-check": "tsc --noEmit --skipLibCheck",

--- a/apps/wms/package.json
+++ b/apps/wms/package.json
@@ -3,7 +3,7 @@
   "version": "0.6.1",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3001",
+    "dev": "node ../../scripts/run-dev-with-logs.js wms -- next dev -p 3001",
     "dev:30001": "next dev -p 30001",
     "dev:turbo": "next dev --turbo",
     "dev:port": "PORT=3001 next dev",

--- a/apps/wms/src/app/auth/login/page.tsx
+++ b/apps/wms/src/app/auth/login/page.tsx
@@ -2,9 +2,17 @@ import { redirect } from 'next/navigation'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 
-export default async function LoginPage({ searchParams }: { searchParams?: { callbackUrl?: string } }) {
-  // Read sync dynamic API (searchParams) before any await to satisfy Next.js constraints
-  const desired = (searchParams?.callbackUrl as string | undefined) || '/dashboard'
+type SearchParamsInput =
+  | { callbackUrl?: string }
+  | Promise<{ callbackUrl?: string } | undefined>
+  | undefined
+
+export default async function LoginPage({ searchParams }: { searchParams?: SearchParamsInput }) {
+  const resolved = await Promise.resolve(searchParams)
+  const desired = typeof resolved?.callbackUrl === 'string' && resolved.callbackUrl.trim().length > 0
+    ? resolved.callbackUrl
+    : '/dashboard'
+
   const session = await getServerSession(authOptions)
   if (session) {
     redirect(desired)

--- a/apps/wms/src/app/page.tsx
+++ b/apps/wms/src/app/page.tsx
@@ -1,16 +1,5 @@
 import { redirect } from 'next/navigation'
-import { getServerSession } from 'next-auth/next'
-import { authOptions } from '@/lib/auth'
-import LandingPage from '@/components/landing-page'
 
-export default async function HomePage() {
-  const session = await getServerSession(authOptions)
-
-  if (session) {
-    // Redirect all authenticated users to unified dashboard
-    redirect('/dashboard')
-  }
-
-  // Show landing page for non-authenticated users
-  return <LandingPage />
+export default function HomePage() {
+  redirect('/dashboard')
 }

--- a/apps/wms/src/components/landing-page.tsx
+++ b/apps/wms/src/components/landing-page.tsx
@@ -143,7 +143,7 @@ export default function LandingPage() {
                 const central = process.env.NEXT_PUBLIC_CENTRAL_AUTH_URL || 'https://ecomos.targonglobal.com'
                 const url = new URL('/login', central)
                 if (typeof window !== 'undefined') {
-                  url.searchParams.set('callbackUrl', window.location.origin)
+                  url.searchParams.set('callbackUrl', `${window.location.origin}/dashboard`)
                 }
                 window.location.href = url.toString()
               }}

--- a/apps/wms/src/lib/auth.ts
+++ b/apps/wms/src/lib/auth.ts
@@ -17,12 +17,17 @@ applyDevAuthDefaults({
   publicCentralUrl: process.env.NEXT_PUBLIC_CENTRAL_AUTH_URL || 'http://localhost:3000',
 })
 
+const sharedSecret = process.env.CENTRAL_AUTH_SECRET || process.env.NEXTAUTH_SECRET
+if (sharedSecret) {
+  process.env.NEXTAUTH_SECRET = sharedSecret
+}
+
 const baseAuthOptions: NextAuthOptions = {
   session: {
     strategy: 'jwt',
     maxAge: 30 * 24 * 60 * 60, // 30 days
   },
-  secret: process.env.NEXTAUTH_SECRET,
+  secret: sharedSecret,
   debug: false,
   // Include a no-op credentials provider so NextAuth routes (csrf/session) function
   // WMS does not authenticate locally; central portal issues the session cookie

--- a/apps/wms/src/lib/auth.ts
+++ b/apps/wms/src/lib/auth.ts
@@ -1,9 +1,21 @@
 import { NextAuthOptions } from 'next-auth'
 import CredentialsProvider from 'next-auth/providers/credentials'
-import { withSharedAuth } from '@ecom-os/auth'
+import { applyDevAuthDefaults, withSharedAuth } from '@ecom-os/auth'
 import { UserRole } from '@prisma/client'
 
 const secure = process.env.NODE_ENV === 'production'
+
+const devPort = process.env.PORT || process.env.WMS_PORT || 3001
+const devBaseUrl = process.env.NEXT_PUBLIC_APP_URL || `http://localhost:${devPort}`
+const centralDev = process.env.CENTRAL_AUTH_URL || 'http://localhost:3000'
+applyDevAuthDefaults({
+  appId: 'ecomos',
+  port: devPort,
+  baseUrl: devBaseUrl,
+  cookieDomain: 'localhost',
+  centralUrl: centralDev,
+  publicCentralUrl: process.env.NEXT_PUBLIC_CENTRAL_AUTH_URL || 'http://localhost:3000',
+})
 
 const baseAuthOptions: NextAuthOptions = {
   session: {
@@ -11,7 +23,7 @@ const baseAuthOptions: NextAuthOptions = {
     maxAge: 30 * 24 * 60 * 60, // 30 days
   },
   secret: process.env.NEXTAUTH_SECRET,
-  debug: process.env.NODE_ENV === 'development',
+  debug: false,
   // Include a no-op credentials provider so NextAuth routes (csrf/session) function
   // WMS does not authenticate locally; central portal issues the session cookie
   providers: [

--- a/apps/wms/src/lib/lucide-icons.ts
+++ b/apps/wms/src/lib/lucide-icons.ts
@@ -60,6 +60,7 @@ export {
   BarChart3,
   TrendingUp,
   TrendingDown,
+  Archive,
   FileText,
   File,
   Folder,

--- a/apps/wms/src/middleware.ts
+++ b/apps/wms/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
-import { getToken } from 'next-auth/jwt'
+import { hasCentralSession } from '@ecom-os/auth'
 import { withBasePath, withoutBasePath } from '@/lib/utils/base-path'
 
 export async function middleware(request: NextRequest) {
@@ -44,35 +44,19 @@ export async function middleware(request: NextRequest) {
   }
 
   // Check for session
-  let token = null
-  try {
-    const namesToTry = [
-      process.env.NODE_ENV === 'production'
-        ? '__Secure-next-auth.session-token'
-        : 'next-auth.session-token',
-      process.env.NODE_ENV === 'production'
-        ? '__Secure-next-auth.session-token'
-        : 'ecomos.next-auth.session-token',
-      // Legacy app-prefixed cookie for WMS during migration
-      process.env.NODE_ENV === 'production'
-        ? '__Secure-wms.next-auth.session-token'
-        : 'wms.next-auth.session-token',
-    ]
+  const cookieNames = process.env.NODE_ENV === 'production'
+    ? ['__Secure-next-auth.session-token', '__Secure-wms.next-auth.session-token']
+    : ['next-auth.session-token', 'ecomos.next-auth.session-token', 'wms.next-auth.session-token']
 
-    for (const name of namesToTry) {
-      token = await getToken({
-        req: request,
-        secret: process.env.NEXTAUTH_SECRET,
-        cookieName: name,
-      })
-      if (token) break
-    }
-  } catch (_error) {
-    // Continue without token - will redirect if needed
-  }
+  const hasSession = await hasCentralSession({
+    request: request as any,
+    cookieNames,
+    centralUrl: process.env.CENTRAL_AUTH_URL,
+    debug: process.env.NODE_ENV !== 'production',
+  })
 
   // If no token and trying to access protected route, redirect to central login
-  if (!token && !normalizedPath.startsWith('/auth/')) {
+  if (!hasSession && !normalizedPath.startsWith('/auth/')) {
     const defaultCentral = process.env.NODE_ENV === 'production'
       ? 'https://ecomos.targonglobal.com'
       : 'http://localhost:3000'

--- a/apps/wms/src/middleware.ts
+++ b/apps/wms/src/middleware.ts
@@ -73,7 +73,10 @@ export async function middleware(request: NextRequest) {
 
   // If no token and trying to access protected route, redirect to central login
   if (!token && !normalizedPath.startsWith('/auth/')) {
-    const central = process.env.CENTRAL_AUTH_URL || 'https://ecomos.targonglobal.com'
+    const defaultCentral = process.env.NODE_ENV === 'production'
+      ? 'https://ecomos.targonglobal.com'
+      : 'http://localhost:3000'
+    const central = process.env.CENTRAL_AUTH_URL || defaultCentral
     const redirect = new URL('/login', central)
     redirect.searchParams.set('callbackUrl', request.nextUrl.toString())
     return NextResponse.redirect(redirect)

--- a/apps/wms/tsconfig.json
+++ b/apps/wms/tsconfig.json
@@ -15,6 +15,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "baseUrl": ".",
     "removeComments": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "packageManager": "pnpm@9.0.0",
   "scripts": {
+    "predev": "node scripts/prepare-dev-logs.js",
     "dev": "turbo run dev --parallel",
     "build": "turbo run build",
     "test": "turbo run test",

--- a/packages/auth/dist/index.d.ts
+++ b/packages/auth/dist/index.d.ts
@@ -30,9 +30,18 @@ export interface SharedAuthOptions {
     cookieDomain: string;
     appId?: string;
 }
+export interface DevAuthDefaultsOptions {
+    appId?: string;
+    port?: string | number;
+    baseUrl?: string;
+    cookieDomain?: string;
+    centralUrl?: string;
+    publicCentralUrl?: string;
+}
 /**
- * Compose app-specific NextAuth options with shared, secure defaults.
+ * Provide sane defaults for local development so NextAuth stops warning about missing env vars.
  */
+export declare function applyDevAuthDefaults(options?: DevAuthDefaultsOptions): void;
 export declare function withSharedAuth(base: NextAuthOptions, optsOrDomain: SharedAuthOptions | string): NextAuthOptions;
 /**
  * Helper to derive the likely session cookie names to probe in middleware.

--- a/packages/auth/dist/index.d.ts
+++ b/packages/auth/dist/index.d.ts
@@ -1,5 +1,6 @@
 import type { NextAuthOptions } from 'next-auth';
 import { z } from 'zod';
+import type { NextRequest } from 'next/server';
 export type SameSite = 'lax' | 'strict' | 'none';
 export interface CookieDomainOptions {
     domain: string;
@@ -48,6 +49,22 @@ export declare function withSharedAuth(base: NextAuthOptions, optsOrDomain: Shar
  * In dev, returns both generic and app-prefixed variants for robustness.
  */
 export declare function getCandidateSessionCookieNames(appId?: string): string[];
+export interface CentralSessionProbeOptions {
+    request: NextRequest;
+    appId?: string;
+    cookieNames?: string[];
+    secret?: string;
+    centralUrl?: string;
+    debug?: boolean;
+    fetchImpl?: typeof fetch;
+}
+/**
+ * Determine whether a request already carries a valid central NextAuth session.
+ * - Tries to decode the session cookie locally using the shared secret.
+ * - Falls back to probing the central `/api/auth/session` endpoint to handle
+ *   environments where app-specific secrets differ from the portal.
+ */
+export declare function hasCentralSession(options: CentralSessionProbeOptions): Promise<boolean>;
 export type AppEntitlement = {
     role: string;
     depts?: string[];

--- a/packages/auth/dist/index.js
+++ b/packages/auth/dist/index.js
@@ -67,10 +67,45 @@ export const AuthEnvSchema = z.object({
 /**
  * Compose app-specific NextAuth options with shared, secure defaults.
  */
+const truthyValues = new Set(['1', 'true', 'yes', 'on']);
+/**
+ * Provide sane defaults for local development so NextAuth stops warning about missing env vars.
+ */
+export function applyDevAuthDefaults(options = {}) {
+    if (process.env.NODE_ENV === 'production')
+        return;
+    if (!process.env.NEXTAUTH_SECRET) {
+        const suffix = options.appId ? `-${options.appId}` : '';
+        // 32+ chars keeps jose happy for local JWT encryption/decryption.
+        process.env.NEXTAUTH_SECRET = `dev-only-nextauth-secret${suffix}-change-me`;
+    }
+    if (!process.env.NEXTAUTH_URL) {
+        const port = options.port ?? process.env.PORT ?? 3000;
+        const baseUrl = options.baseUrl ?? `http://localhost:${port}`;
+        process.env.NEXTAUTH_URL = String(baseUrl);
+    }
+    if (!process.env.COOKIE_DOMAIN && options.cookieDomain) {
+        process.env.COOKIE_DOMAIN = options.cookieDomain;
+    }
+    if (!process.env.CENTRAL_AUTH_URL && options.centralUrl) {
+        process.env.CENTRAL_AUTH_URL = options.centralUrl;
+    }
+    if (!process.env.NEXT_PUBLIC_CENTRAL_AUTH_URL && options.publicCentralUrl) {
+        process.env.NEXT_PUBLIC_CENTRAL_AUTH_URL = options.publicCentralUrl;
+    }
+    if (process.env.NEXTAUTH_DEBUG === undefined) {
+        // Default to off; callers can opt-in with NEXTAUTH_DEBUG=1 if needed.
+        process.env.NEXTAUTH_DEBUG = '0';
+    }
+}
 export function withSharedAuth(base, optsOrDomain) {
     const opts = typeof optsOrDomain === 'string'
         ? { cookieDomain: optsOrDomain }
         : optsOrDomain;
+    const envDebug = process.env.NEXTAUTH_DEBUG ? truthyValues.has(process.env.NEXTAUTH_DEBUG.toLowerCase()) : undefined;
+    const baseDebug = typeof base.debug === 'boolean' ? base.debug : undefined;
+    const debug = envDebug ?? baseDebug ?? false;
+    const secret = process.env.NEXTAUTH_SECRET ?? base.secret;
     return {
         // Keep base providers/callbacks etc. from app
         ...base,
@@ -79,8 +114,8 @@ export function withSharedAuth(base, optsOrDomain) {
             maxAge: 30 * 24 * 60 * 60,
             ...base.session,
         },
-        debug: process.env.NODE_ENV === 'development' || !!base.debug,
-        secret: process.env.NEXTAUTH_SECRET ?? base.secret,
+        debug,
+        secret,
         cookies: {
             ...buildCookieOptions({ domain: opts.cookieDomain, sameSite: 'lax', appId: opts.appId }),
             ...base.cookies,

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,5 +1,7 @@
 import type { NextAuthOptions } from 'next-auth';
+import { getToken } from 'next-auth/jwt';
 import { z } from 'zod';
+import type { NextRequest } from 'next/server';
 
 export type SameSite = 'lax' | 'strict' | 'none';
 
@@ -177,6 +179,115 @@ export function getCandidateSessionCookieNames(appId?: string): string[] {
     if (appId) names.push(`${appId}.next-auth.session-token`);
   }
   return names;
+}
+
+export interface CentralSessionProbeOptions {
+  request: NextRequest;
+  appId?: string;
+  cookieNames?: string[];
+  secret?: string;
+  centralUrl?: string;
+  debug?: boolean;
+  fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_CENTRAL_PROD = 'https://ecomos.targonglobal.com';
+const DEFAULT_CENTRAL_DEV = 'http://localhost:3000';
+const missingSecretWarnings = new Set<string>();
+
+/**
+ * Determine whether a request already carries a valid central NextAuth session.
+ * - Tries to decode the session cookie locally using the shared secret.
+ * - Falls back to probing the central `/api/auth/session` endpoint to handle
+ *   environments where app-specific secrets differ from the portal.
+ */
+export async function hasCentralSession(options: CentralSessionProbeOptions): Promise<boolean> {
+  const {
+    request,
+    appId,
+    cookieNames,
+    debug = process.env.NODE_ENV !== 'production',
+    fetchImpl,
+  } = options;
+
+  const names = Array.from(new Set((cookieNames && cookieNames.length > 0)
+    ? cookieNames
+    : getCandidateSessionCookieNames(appId)));
+
+  const sharedSecret = options.secret
+    || process.env.CENTRAL_AUTH_SECRET
+    || process.env.NEXTAUTH_SECRET;
+
+  if (sharedSecret) {
+    for (const name of names) {
+      try {
+        const token = await getToken({
+          req: request as any,
+          secret: sharedSecret,
+          cookieName: name,
+        });
+        if (token) {
+          return true;
+        }
+      } catch (error) {
+        if (debug) {
+          const detail = error instanceof Error ? error.message : String(error);
+          console.warn('[auth] failed to decode session cookie', name, detail);
+        }
+      }
+    }
+  } else if (debug) {
+    const warnKey = names.join('|') || 'global';
+    if (!missingSecretWarnings.has(warnKey)) {
+      missingSecretWarnings.add(warnKey);
+      console.warn('[auth] missing shared NEXTAUTH_SECRET; falling back to central probe');
+    }
+  }
+
+  const cookieHeader = request.headers.get('cookie');
+  if (!cookieHeader) {
+    return false;
+  }
+
+  const hasCandidateCookie = names.some((name) => cookieHeader.includes(`${name}=`));
+  if (!hasCandidateCookie) {
+    return false;
+  }
+
+  const centralBase = options.centralUrl
+    || process.env.CENTRAL_AUTH_URL
+    || (process.env.NODE_ENV === 'production' ? DEFAULT_CENTRAL_PROD : DEFAULT_CENTRAL_DEV);
+
+  if (!centralBase) {
+    return false;
+  }
+
+  try {
+    const endpoint = new URL('/api/auth/session', centralBase);
+    const res = await (fetchImpl ?? fetch)(endpoint, {
+      method: 'GET',
+      headers: {
+        cookie: cookieHeader,
+        accept: 'application/json',
+        'x-ecomos-session-probe': '1',
+      },
+      cache: 'no-store',
+    });
+    if (!res.ok) {
+      if (debug) {
+        console.warn('[auth] central session probe returned status', res.status);
+      }
+      return false;
+    }
+    const data = await res.json().catch(() => null);
+    return !!data?.user;
+  } catch (error) {
+    if (debug) {
+      const detail = error instanceof Error ? error.message : String(error);
+      console.warn('[auth] central session probe failed', detail);
+    }
+    return false;
+  }
 }
 
 // ===== Entitlement / Roles claim helpers =====

--- a/scripts/prepare-dev-logs.js
+++ b/scripts/prepare-dev-logs.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const path = require('path')
+
+const logDir = path.resolve(__dirname, '..', 'logs')
+
+try {
+  fs.rmSync(logDir, { recursive: true, force: true })
+} catch (error) {
+  // Ignore removal errors
+}
+
+fs.mkdirSync(logDir, { recursive: true })
+
+const defaultLogs = ['ecomos', 'hrms', 'wms']
+for (const name of defaultLogs) {
+  const target = path.join(logDir, `${name}.log`)
+  try {
+    fs.writeFileSync(target, '', { flag: 'w' })
+  } catch (error) {
+    console.warn(`[prepare-dev-logs] Unable to seed log file ${name}.log`, error)
+  }
+}

--- a/scripts/run-dev-with-logs.js
+++ b/scripts/run-dev-with-logs.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+const args = process.argv.slice(2)
+if (args.length < 3) {
+  console.error('Usage: run-dev-with-logs <logName> -- <command> [args...]')
+  process.exit(1)
+}
+
+const separatorIndex = args.indexOf('--')
+if (separatorIndex === -1 || separatorIndex === 0 || separatorIndex === args.length - 1) {
+  console.error('Usage: run-dev-with-logs <logName> -- <command> [args...]')
+  process.exit(1)
+}
+
+const logName = args[0]
+const command = args[separatorIndex + 1]
+const commandArgs = args.slice(separatorIndex + 2)
+
+const logDir = path.resolve(__dirname, '..', 'logs')
+fs.mkdirSync(logDir, { recursive: true })
+
+const defaultLogs = ['ecomos', 'hrms', 'wms']
+for (const name of defaultLogs) {
+  const file = path.join(logDir, `${name}.log`)
+  try {
+    if (!fs.existsSync(file)) {
+      fs.writeFileSync(file, '')
+    }
+  } catch (error) {
+    console.warn(`[run-dev-with-logs] Unable to ensure ${file}`, error)
+  }
+}
+
+const logPath = path.join(logDir, `${logName}.log`)
+try {
+  fs.writeFileSync(logPath, '')
+} catch (error) {
+  console.warn(`[run-dev-with-logs] Unable to reset ${logPath}`, error)
+}
+
+const logStream = fs.createWriteStream(logPath, { flags: 'a' })
+
+const sharedSecret = process.env.CENTRAL_AUTH_SECRET
+  || process.env.NEXTAUTH_SECRET
+  || 'dev-only-shared-nextauth-secret-change-me'
+
+const child = spawn(command, commandArgs, {
+  stdio: ['inherit', 'pipe', 'pipe'],
+  shell: false,
+  env: {
+    ...process.env,
+    DEV_LOG_NAME: logName,
+    CENTRAL_AUTH_SECRET: sharedSecret,
+    NEXTAUTH_SECRET: sharedSecret,
+  },
+})
+
+function forward(stream, target) {
+  stream.on('data', (chunk) => {
+    const data = chunk.toString()
+    target.write(data)
+    logStream.write(data)
+  })
+}
+
+forward(child.stdout, process.stdout)
+forward(child.stderr, process.stderr)
+
+child.on('close', (code) => {
+  logStream.end(() => {
+    if (code !== 0) {
+      process.exit(code)
+    }
+  })
+})
+
+child.on('error', (error) => {
+  console.error(`[run-dev-with-logs] Failed to start command: ${error.message}`)
+  logStream.end(() => process.exit(1))
+})


### PR DESCRIPTION
## Summary
- promote CENTRAL_AUTH_SECRET so portal and satellite apps share the NextAuth secret in dev
- rely on shared helper in app middleware to read the central cookie without redirect loops
- wrap all dev scripts with log-capturing wrapper and fix WMS login route acc. to Next.js 15 rules

## Testing
- pnpm --filter @ecom-os/wms build