### PR TITLE
docs: branch naming format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,4 +32,4 @@
 - Group changes by app or shared package and mention additional workspaces touched when scopes differ.
 - PRs should include purpose, testing evidence (`pnpm lint && pnpm test`), screenshots for UI shifts, and linked GitHub issues.
 - Request owners of affected apps and shared packages as reviewers; flag infra updates for DevOps before merge.
-- Branching: use short-lived `feature/*` branches off `dev`, merge via PR with passing checks, and advance `main` only through deliberate release PRs; never push directly to `main`.
+- Branching: use short-lived `app-name/feature-name` branches off `dev` (e.g., `website/website-hydration`, `hrms/test-feature`), merge via PR with passing checks, and advance `main` only through deliberate release PRs; never push directly to `main`.


### PR DESCRIPTION
Update branching guidance to enforce app/feature convention.