### PR TITLE
chore(wms): bump version to 0.7.0

### DIFF
--- a/apps/wms/package.json
+++ b/apps/wms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecom-os/wms",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "private": true,
   "scripts": {
     "dev": "node ../../scripts/run-dev-with-logs.js wms -- next dev -p 3001",


### PR DESCRIPTION
## Summary
- bump @ecom-os/wms package version to 0.7.0 ahead of release

## Testing
- pnpm --filter @ecom-os/wms lint
- pnpm --filter @ecom-os/wms type-check
- pnpm --filter @ecom-os/wms build
