### PR TITLE
chore(cd): deploy wms app alongside website

### DIFF
--- a/infra/ansible/deploy-monorepo.yml
+++ b/infra/ansible/deploy-monorepo.yml
@@ -189,6 +189,24 @@
             echo "Content verification OK"; break; fi; sleep 3; done
         curl -fsS -H "Host: {{ website_server_name | default('www.targonglobal.com') }}" "http://127.0.0.1:{{ website_port }}/" | grep -Eiq '(INNOVATION TO IMPACT|Everyday, Done Better)' || (echo 'ERROR: Content verification failed on localhost' >&2; exit 1)
       args: { chdir: "{{ app_base }}/repo" }
+
+    - name: Start WMS with PM2 (clean restart + verify)
+      shell: |
+        set -e
+        cd {{ app_base }}/repo
+        pm2 delete wms || true
+        lsof -ti:{{ wms_port }} | xargs -r kill -9 || true
+        rm -rf apps/wms/.next
+        pnpm --filter @ecom-os/wms build
+        pm2 delete wms || true
+        PORT={{ wms_port }} NODE_ENV=production pm2 start server.js --name wms --cwd {{ app_base }}/repo/apps/wms --update-env
+        pm2 save
+        # Verify WMS health returns 200 and new version string
+        for i in 1 2 3 4 5 6 7 8 9 10; do
+          if curl -fsS -H "Host: {{ wms_server_name | default('wms.targonglobal.com') }}" "http://127.0.0.1:{{ wms_port }}/api/health" | grep -q '"status":"ok"'; then
+            echo "WMS health check OK"; break; fi; sleep 3; done
+        curl -fsS -H "Host: {{ wms_server_name | default('wms.targonglobal.com') }}" "http://127.0.0.1:{{ wms_port }}/api/health" | grep -q '"status":"ok"' || (echo 'ERROR: WMS health check failed on localhost' >&2; exit 1)
+      args: { chdir: "{{ app_base }}/repo" }
   handlers:
     - name: restart nginx
       systemd: { name: nginx, state: restarted }


### PR DESCRIPTION
## Summary
- update the monorepo deploy playbook to build and restart the WMS app via PM2
- reuse the existing WMS env secret, rebuild the Next bundle, and validate /api/health after deploy

## Testing
- (deployment playbook change only)
