### PR TITLE
infra(cd): harden deploy pipeline

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -24,6 +24,7 @@ jobs:
       AWS_REGION: ${{ secrets.AWS_REGION }}
       EC2_HOST_SECRET: ${{ secrets.EC2_HOST }}
       EC2_USER_SECRET: ${{ secrets.EC2_USER }}
+      EC2_INSTANCE_ID_SECRET: ${{ secrets.EC2_INSTANCE_ID }}
       CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
     concurrency:
       group: prod-main
@@ -57,9 +58,18 @@ jobs:
       - name: Discover EC2 host (if AWS creds available)
         if: ${{ env.AWS_ROLE_TO_ASSUME != '' && env.AWS_REGION != '' }}
         run: |
-          read INST_ID INST_AZ INST_IP < <(aws ec2 describe-instances \
-            --filters Name=instance-state-name,Values=running \
-            --query 'Reservations[0].Instances[0].[InstanceId,Placement.AvailabilityZone,PublicIpAddress]' --output text)
+          set -euo pipefail
+          if [ -n "${EC2_INSTANCE_ID_SECRET:-}" ]; then
+            QUERY_OPTS=(--instance-ids "$EC2_INSTANCE_ID_SECRET")
+          else
+            QUERY_OPTS=(--filters "Name=instance-state-name,Values=running")
+          fi
+          read INST_ID INST_AZ INST_IP < <(aws ec2 describe-instances "${QUERY_OPTS[@]}" \
+            --query 'Reservations[0].Instances[0].[InstanceId,Placement.AvailabilityZone,PublicIpAddress]' --output text || true)
+          if [ -z "${INST_IP:-}" ] || [ "${INST_IP}" = "None" ]; then
+            echo "No matching EC2 instance with public IP found via AWS lookup" >&2
+            exit 0
+          fi
           echo "EC2_HOST=$INST_IP" >> $GITHUB_ENV
           echo "EIC_INSTANCE_ID=$INST_ID" >> $GITHUB_ENV
           echo "EIC_INSTANCE_AZ=$INST_AZ" >> $GITHUB_ENV
@@ -72,9 +82,12 @@ jobs:
           fi
           echo "EC2_USER=${EC2_USER_SECRET}" >> $GITHUB_ENV
 
-      - name: Append known_hosts for EC2
+      - name: Validate EC2 host resolved
         run: |
-          ssh-keyscan -H "$EC2_HOST" >> ~/.ssh/known_hosts
+          if [ -z "${EC2_HOST:-}" ]; then
+            echo "::error title=Missing EC2 host::Failed to resolve EC2 host. Provide AWS filters or set EC2_HOST secret." >&2
+            exit 1
+          fi
 
       - name: Generate and inject CI SSH key via EC2 Instance Connect
         if: ${{ env.AWS_ROLE_TO_ASSUME != '' && env.AWS_REGION != '' }}
@@ -95,6 +108,35 @@ jobs:
             "mkdir -p ~/.ssh && touch ~/.ssh/authorized_keys && grep -qxF '$(cat ~/.ssh/ci_key.pub)' ~/.ssh/authorized_keys || echo '$(cat ~/.ssh/ci_key.pub)' >> ~/.ssh/authorized_keys && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys"
           # Switch default key for subsequent steps
           install -m 600 -D ~/.ssh/ci_key ~/.ssh/id_rsa
+
+      - name: Append known_hosts for EC2
+        run: |
+          ssh-keyscan -H "$EC2_HOST" >> ~/.ssh/known_hosts
+
+      - name: Check remote disk usage before deploy
+        continue-on-error: true
+        env:
+          OS_USER: ${{ env.EC2_USER_SECRET }}
+        run: |
+          set -e
+          OS_USER=${OS_USER:-${EC2_USER:-ubuntu}}
+          ssh -o StrictHostKeyChecking=no "$OS_USER@$EC2_HOST" 'bash -s' <<'REMOTE'
+set -e
+df -h
+echo
+echo "Top-level usage:"
+sudo du -sh /opt/ecom-os /var/log || true
+echo
+echo "/opt/ecom-os breakdown:"
+sudo du -sh /opt/ecom-os/* 2>/dev/null | sort -hr | head || true
+echo
+echo "User cache breakdown:"
+sudo du -sh "$HOME/.local/share/pnpm" "$HOME/.local/state/pnpm" "$HOME/.pnpm-store" 2>/dev/null || true
+sudo du -sh "$HOME/.cache" 2>/dev/null | sort -hr | head || true
+echo
+echo "PM2 logs:"
+sudo du -sh "$HOME/.pm2/logs" 2>/dev/null || true
+REMOTE
 
       - name: Update Cloudflare DNS (apex + www) to EC2
         continue-on-error: true

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -2,7 +2,8 @@
 host_key_checking = False
 inventory = inventory/production.yml
 remote_user = ubuntu
-private_key_file = ~/.ssh/wms-deploy-key.pem
+# Default to the key GitHub Actions provisions in deploy-prod
+private_key_file = ~/.ssh/id_rsa
 stdout_callback = yaml
 deprecation_warnings = False
 

--- a/infra/ansible/deploy-monorepo.yml
+++ b/infra/ansible/deploy-monorepo.yml
@@ -207,6 +207,27 @@
             echo "WMS health check OK"; break; fi; sleep 3; done
         curl -fsS -H "Host: {{ wms_server_name | default('wms.targonglobal.com') }}" "http://127.0.0.1:{{ wms_port }}/api/health" | grep -q '"status":"ok"' || (echo 'ERROR: WMS health check failed on localhost' >&2; exit 1)
       args: { chdir: "{{ app_base }}/repo" }
+
+    - name: Install ecomos housekeeping script
+      template:
+        src: ecomos-cleanup.sh.j2
+        dest: /usr/local/bin/ecomos-cleanup.sh
+        mode: '0755'
+        owner: root
+        group: root
+
+    - name: Install ecomos housekeeping cron job
+      template:
+        src: ecomos-cleanup-cron.sh.j2
+        dest: /etc/cron.weekly/ecomos-cleanup
+        mode: '0755'
+        owner: root
+        group: root
+
+    - name: Run housekeeping cleanup now
+      command: /usr/local/bin/ecomos-cleanup.sh
+      args:
+        warn: false
   handlers:
     - name: restart nginx
       systemd: { name: nginx, state: restarted }

--- a/infra/ansible/templates/ecomos-cleanup-cron.sh.j2
+++ b/infra/ansible/templates/ecomos-cleanup-cron.sh.j2
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/local/bin/ecomos-cleanup.sh >> /var/log/ecomos-cleanup.log 2>&1

--- a/infra/ansible/templates/ecomos-cleanup.sh.j2
+++ b/infra/ansible/templates/ecomos-cleanup.sh.j2
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf "%s %s\n" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$1"
+}
+
+run_as_ubuntu() {
+  su - ubuntu -s /bin/bash -c "$1"
+}
+
+log "starting ecomos cleanup"
+
+run_as_ubuntu "rm -rf ~/.npm ~/.cache/ms-playwright ~/.cache/puppeteer ~/.cache/playwright ~/.cache/npm || true" || log "warning: failed to clear ubuntu caches"
+
+if command -v pnpm >/dev/null 2>&1; then
+  run_as_ubuntu "pnpm store prune || true" || log "warning: pnpm store prune failed"
+else
+  log "warning: pnpm not found on path; skipping pnpm store prune"
+fi
+
+run_as_ubuntu "rm -f ~/.pm2/logs/*.log* || true"
+
+journalctl --vacuum-time=14d || log "warning: journalctl vacuum failed"
+truncate -s0 /var/log/nginx/access.log /var/log/nginx/error.log 2>/dev/null || true
+find /var/log -type f -name '*.gz' -delete || true
+find /var/log -type f -name '*.log.*' -delete || true
+
+apt-get clean || log "warning: apt-get clean failed"
+rm -rf /var/lib/apt/lists/* || true
+rm -rf /var/lib/snapd/cache/* || true
+
+log "cleanup completed"


### PR DESCRIPTION
## Summary
- align Ansible SSH key with CI identity
- log EC2 disk usage and install recurring cleanup via Ansible
- prune caches/logs each deploy to keep disk headroom

## Testing
- gh workflow run deploy-prod.yml --ref infra/fix-cd-ssh-key