### PR TITLE
infra(pm2): drop legacy wms-app entry

### DIFF
--- a/infra/ansible/deploy-monorepo.yml
+++ b/infra/ansible/deploy-monorepo.yml
@@ -194,6 +194,7 @@
       shell: |
         set -e
         cd {{ app_base }}/repo
+        pm2 delete wms-app || true
         pm2 delete wms || true
         lsof -ti:{{ wms_port }} | xargs -r kill -9 || true
         rm -rf apps/wms/.next


### PR DESCRIPTION
## Summary
- remove old pm2 process name wms-app before restart to avoid port conflicts

## Testing
- gh workflow run deploy-prod.yml --ref infra/fix-wms-pm2