### PR TITLE
ci(cd): fix workflow dispatch syntax

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -9,7 +9,7 @@ on:
       - 'infra/ansible/**'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
-  workflow_dispatch: {}
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
- represent workflow_dispatch trigger without empty map to satisfy GitHub API

## Testing
- gh api repos/progami/ecom-os/actions/workflows/deploy-prod.yml/dispatches -f ref=infra/fix-dispatch