### PR TITLE
release: promote dev to main

### DIFF
--- a/infra/ansible/deploy-monorepo.yml
+++ b/infra/ansible/deploy-monorepo.yml
@@ -228,8 +228,6 @@
 
     - name: Run housekeeping cleanup now
       shell: /usr/local/bin/ecomos-cleanup.sh
-      args:
-        warn: false
   handlers:
     - name: restart nginx
       systemd: { name: nginx, state: restarted }


### PR DESCRIPTION
## Summary
- remove unsupported warn flag now that cleanup shell runs via shell module
- prior CD hardening changes (cleanup automation, prisma generate, etc.)

## Testing
- ./actionlint .github/workflows/deploy-prod.yml