### PR TITLE
infra(central): serve wms under portal path

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -26,6 +26,7 @@ jobs:
       EC2_USER_SECRET: ${{ secrets.EC2_USER }}
       EC2_INSTANCE_ID_SECRET: ${{ secrets.EC2_INSTANCE_ID }}
       CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+      ECOMOS_ENV: ${{ secrets.ECOMOS_ENV }}
     concurrency:
       group: prod-main
       cancel-in-progress: false
@@ -166,6 +167,8 @@ jobs:
           }
           upsert_a "$CF_ZONE_NAME" "$EC2_HOST" false
           upsert_a "www.$CF_ZONE_NAME" "$EC2_HOST" false
+          upsert_a "ecomos.$CF_ZONE_NAME" "$EC2_HOST" false
+          upsert_a "wms.$CF_ZONE_NAME" "$EC2_HOST" false
 
       - name: Write inventory
         run: |
@@ -199,6 +202,7 @@ jobs:
           CENTRAL_DB_ENV: ${{ secrets.CENTRAL_DB_ENV }}
           MARGIN_MASTER_ENV: ${{ secrets.MARGIN_MASTER_ENV }}
           JASON_ENV: ${{ secrets.JASON_ENV }}
+          ECOMOS_ENV: ${{ secrets.ECOMOS_ENV }}
         run: |
           set -e
           echo "Inventory:" && cat infra/ansible/inventory/hosts.ini

--- a/apps/ecomos/lib/apps.ts
+++ b/apps/ecomos/lib/apps.ts
@@ -18,7 +18,7 @@ export const ALL_APPS: AppDef[] = [
     id: 'wms',
     name: 'Warehouse Management',
     description: 'Inbound, outbound, inventory and reporting.',
-    url: 'https://wms.targonglobal.com',
+    url: 'https://ecomos.targonglobal.com/wms',
     category: 'Ops',
     roles: ['admin', 'manager', 'staff']
   },

--- a/infra/ansible/deploy-monorepo.yml
+++ b/infra/ansible/deploy-monorepo.yml
@@ -7,13 +7,17 @@
     node_version: "20"
     repo_url: "git@github.com:YOUR_ORG/YOUR_REPO.git"
     use_local_copy: true
-    website_port: 3000
+    website_port: 3005
     wms_port: 3001
     fcc_port: 3003
     hrms_port: 3006
+    ecomos_port: 3000
     central_db_port: 3004
     margin_master_port: 3007
     jason_port: 3008
+    central_portal_url: "https://{{ ecomos_server_name | default('ecomos.targonglobal.com') }}"
+    wms_public_url: "{{ central_portal_url }}/wms"
+    wms_nextauth_url: "{{ central_portal_url }}/wms/api/auth"
   tasks:
     - name: Ensure system deps
       apt:
@@ -121,6 +125,16 @@
             mode: '0600'
           no_log: true
           when: (lookup('env', 'JASON_ENV') | default('', true)) | length > 0
+
+        - name: Write EcomOS env
+          copy:
+            dest: "{{ app_base }}/repo/apps/ecomos/.env"
+            content: "{{ lookup('env', 'ECOMOS_ENV') | default('', true) }}"
+            owner: ubuntu
+            group: ubuntu
+            mode: '0600'
+          no_log: true
+          when: (lookup('env', 'ECOMOS_ENV') | default('', true)) | length > 0
     - name: Write Nginx config
       template:
         src: nginx-monorepo.conf.j2
@@ -190,6 +204,27 @@
         curl -fsS -H "Host: {{ website_server_name | default('www.targonglobal.com') }}" "http://127.0.0.1:{{ website_port }}/" | grep -Eiq '(INNOVATION TO IMPACT|Everyday, Done Better)' || (echo 'ERROR: Content verification failed on localhost' >&2; exit 1)
       args: { chdir: "{{ app_base }}/repo" }
 
+    - name: Build EcomOS portal
+      shell: |
+        set -e
+        pnpm --filter @ecom-os/ecomos build
+      args: { chdir: "{{ app_base }}/repo" }
+
+    - name: Start EcomOS portal with PM2 (clean restart + verify)
+      shell: |
+        set -e
+        cd {{ app_base }}/repo
+        pm2 delete ecomos || true
+        lsof -ti:{{ ecomos_port }} | xargs -r kill -9 || true
+        rm -rf apps/ecomos/.next
+        PORT={{ ecomos_port }} NODE_ENV=production NEXTAUTH_URL={{ central_portal_url }}/api/auth COOKIE_DOMAIN=.targonglobal.com CENTRAL_AUTH_URL={{ central_portal_url }} pm2 start pnpm --name ecomos --cwd {{ app_base }}/repo/apps/ecomos --update-env -- start
+        pm2 save
+        for i in 1 2 3 4 5 6 7 8 9 10; do
+          if curl -fsS -o /dev/null -H "Host: {{ ecomos_server_name | default('ecomos.targonglobal.com') }}" "http://127.0.0.1:{{ ecomos_port }}/login"; then
+            echo "Portal verification OK"; break; fi; sleep 3; done
+        curl -fsS -o /dev/null -H "Host: {{ ecomos_server_name | default('ecomos.targonglobal.com') }}" "http://127.0.0.1:{{ ecomos_port }}/"
+      args: { chdir: "{{ app_base }}/repo" }
+
     - name: Start WMS with PM2 (clean restart + verify)
       shell: |
         set -e
@@ -198,16 +233,16 @@
         pm2 delete wms || true
         lsof -ti:{{ wms_port }} | xargs -r kill -9 || true
         rm -rf apps/wms/.next
-        pnpm --filter @ecom-os/wms db:generate
-        pnpm --filter @ecom-os/wms build
+        BASE_PATH=/wms NEXT_PUBLIC_BASE_PATH=/wms NEXTAUTH_URL={{ wms_nextauth_url }} NEXT_PUBLIC_APP_URL={{ wms_public_url }} NEXT_PUBLIC_CENTRAL_AUTH_URL={{ central_portal_url }} CENTRAL_AUTH_URL={{ central_portal_url }} CSRF_ALLOWED_ORIGINS={{ central_portal_url }},{{ wms_public_url }} pnpm --filter @ecom-os/wms db:generate
+        BASE_PATH=/wms NEXT_PUBLIC_BASE_PATH=/wms NEXTAUTH_URL={{ wms_nextauth_url }} NEXT_PUBLIC_APP_URL={{ wms_public_url }} NEXT_PUBLIC_CENTRAL_AUTH_URL={{ central_portal_url }} CENTRAL_AUTH_URL={{ central_portal_url }} CSRF_ALLOWED_ORIGINS={{ central_portal_url }},{{ wms_public_url }} pnpm --filter @ecom-os/wms build
         pm2 delete wms || true
-        PORT={{ wms_port }} NODE_ENV=production pm2 start server.js --name wms --cwd {{ app_base }}/repo/apps/wms --update-env
+        BASE_PATH=/wms NEXT_PUBLIC_BASE_PATH=/wms NEXTAUTH_URL={{ wms_nextauth_url }} NEXT_PUBLIC_APP_URL={{ wms_public_url }} NEXT_PUBLIC_CENTRAL_AUTH_URL={{ central_portal_url }} CENTRAL_AUTH_URL={{ central_portal_url }} CSRF_ALLOWED_ORIGINS={{ central_portal_url }},{{ wms_public_url }} PORT={{ wms_port }} NODE_ENV=production pm2 start server.js --name wms --cwd {{ app_base }}/repo/apps/wms --update-env
         pm2 save
         # Verify WMS health returns 200 and new version string
         for i in 1 2 3 4 5 6 7 8 9 10; do
-          if curl -fsS -H "Host: {{ wms_server_name | default('wms.targonglobal.com') }}" "http://127.0.0.1:{{ wms_port }}/api/health" | grep -q '"status":"ok"'; then
+          if curl -fsS -H "Host: {{ ecomos_server_name | default('ecomos.targonglobal.com') }}" "http://127.0.0.1:{{ wms_port }}/wms/api/health" | grep -q '"status":"ok"'; then
             echo "WMS health check OK"; break; fi; sleep 3; done
-        curl -fsS -H "Host: {{ wms_server_name | default('wms.targonglobal.com') }}" "http://127.0.0.1:{{ wms_port }}/api/health" | grep -q '"status":"ok"' || (echo 'ERROR: WMS health check failed on localhost' >&2; exit 1)
+        curl -fsS -H "Host: {{ ecomos_server_name | default('ecomos.targonglobal.com') }}" "http://127.0.0.1:{{ wms_port }}/wms/api/health" | grep -q '"status":"ok"' || (echo 'ERROR: WMS health check failed on localhost' >&2; exit 1)
       args: { chdir: "{{ app_base }}/repo" }
 
     - name: Install ecomos housekeeping script

--- a/infra/ansible/group_vars/all.yml
+++ b/infra/ansible/group_vars/all.yml
@@ -9,10 +9,10 @@ git_branch: main
 github_deploy_key_path: ~/.ssh/github_deploy
 
 # Application Configuration
-nextauth_url: "https://targonglobal.com/WMS"
+nextauth_url: "https://ecomos.targonglobal.com/wms/api/auth"
 nextauth_secret: production_secret_key_change_in_production
 node_env: production
-base_path: "/WMS"
+base_path: "/wms"
 app_port: 3001
 
 # Demo Data
@@ -44,6 +44,7 @@ s3_presigned_url_expiry: 3600
 # Monorepo vhost configuration (used by deploy-monorepo.yml)
 website_server_name: www.targonglobal.com
 wms_server_name: wms.targonglobal.com
+ecomos_server_name: ecomos.targonglobal.com
 fcc_server_name: fcc.targonglobal.com
 hrms_server_name: hrms.targonglobal.com
 central_db_server_name: centraldb.targonglobal.com

--- a/infra/ansible/nginx-monorepo.conf.j2
+++ b/infra/ansible/nginx-monorepo.conf.j2
@@ -5,7 +5,10 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $host;
-    proxy_pass http://127.0.0.1:{{ website_port | default(3000) }};
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_pass http://127.0.0.1:{{ website_port | default(3005) }};
   }
 }
 
@@ -18,13 +21,37 @@ server {
 
 server {
   listen 80;
-  server_name {{ wms_server_name | default('wms.targonglobal.com') }};
+  server_name {{ ecomos_server_name | default('ecomos.targonglobal.com') }};
+
+  location /wms/ {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Host $host;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_pass http://127.0.0.1:{{ wms_port | default(3001) }};
+  }
+
+  location = /wms {
+    return 301 $scheme://$host/wms/;
+  }
+
   location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $host;
-    proxy_pass http://127.0.0.1:{{ wms_port | default(3001) }};
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_pass http://127.0.0.1:{{ ecomos_port | default(3000) }};
   }
+}
+
+server {
+  listen 80;
+  server_name {{ wms_server_name | default('wms.targonglobal.com') }};
+  return 301 https://{{ ecomos_server_name | default('ecomos.targonglobal.com') }}$request_uri;
 }
 
 server {
@@ -34,6 +61,9 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $host;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
     proxy_pass http://127.0.0.1:{{ fcc_port | default(3003) }};
   }
 }
@@ -45,6 +75,9 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $host;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
     proxy_pass http://127.0.0.1:{{ hrms_port | default(3006) }};
   }
 }
@@ -58,6 +91,9 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $host;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
     proxy_pass http://127.0.0.1:{{ central_db_port | default(3004) }};
   }
 }
@@ -71,6 +107,9 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $host;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
     proxy_pass http://127.0.0.1:{{ margin_master_port | default(3007) }};
   }
 }
@@ -84,6 +123,9 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $host;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
     proxy_pass http://127.0.0.1:{{ jason_port | default(3008) }};
   }
 }


### PR DESCRIPTION
## Summary
- proxy wms behind the central portal and redirect legacy hostname
- run ecomOS portal in deploy pipeline, update pm2 and env handling
- update Cloudflare A records and portal app catalog for new URL

## Testing
- ./actionlint .github/workflows/deploy-prod.yml