### PR TITLE
infra(nginx): drop connection_upgrade var

### DIFF
--- a/infra/ansible/nginx-monorepo.conf.j2
+++ b/infra/ansible/nginx-monorepo.conf.j2
@@ -125,7 +125,7 @@ server {
     proxy_set_header Host $host;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
+    proxy_set_header Connection "upgrade";
     proxy_pass http://127.0.0.1:{{ jason_port | default(3008) }};
   }
 }


### PR DESCRIPTION
## Summary
- remove leftover  references so nginx reloads cleanly

## Testing
- tailscale ssh ubuntu@ecomos "sudo nginx -t" (after deploy)