### PR TITLE
infra(cert): cover portal subdomains

### DIFF
--- a/infra/ansible/deploy-monorepo.yml
+++ b/infra/ansible/deploy-monorepo.yml
@@ -173,9 +173,11 @@
 
     - name: Obtain/ensure Let's Encrypt cert for apex + www
       command: >-
-        certbot --nginx --reinstall
+        certbot --nginx --reinstall --expand
         -d {{ root_server_name | default('targonglobal.com') }}
         -d {{ website_server_name | default('www.targonglobal.com') }}
+        -d {{ ecomos_server_name | default('ecomos.targonglobal.com') }}
+        -d {{ wms_server_name | default('wms.targonglobal.com') }}
         --non-interactive --agree-tos
         --email {{ certbot_email | default('admin@targonglobal.com') }}
         --redirect

--- a/infra/ansible/nginx-monorepo.conf.j2
+++ b/infra/ansible/nginx-monorepo.conf.j2
@@ -23,7 +23,7 @@ server {
   listen 80;
   server_name {{ ecomos_server_name | default('ecomos.targonglobal.com') }};
 
-  location /wms/ {
+  location ^~ /wms {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $host;
@@ -31,10 +31,6 @@ server {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_pass http://127.0.0.1:{{ wms_port | default(3001) }};
-  }
-
-  location = /wms {
-    return 301 $scheme://$host/wms/;
   }
 
   location / {


### PR DESCRIPTION
## Summary
- renew portal cert to include ecomos & wms SANs
- stop nginx  redirect loop by routing everything through the proxy

## Testing
- gh workflow run CD --ref infra/portal-ssl
- curl -I https://ecomos.targonglobal.com/login
- curl -I https://ecomos.targonglobal.com/wms