### PR TITLE
x-plan: move finance assumptions to product setup context

### DIFF
--- a/apps/x-plan/components/sheets/product-setup-panels.tsx
+++ b/apps/x-plan/components/sheets/product-setup-panels.tsx
@@ -102,3 +102,19 @@ export function BusinessParametersPanel({ parameters }: { parameters: BusinessPa
     </section>
   )
 }
+
+export function ProductSetupFinancePanel({ parameters }: { parameters: BusinessParameter[] }) {
+  if (parameters.length === 0) return null
+
+  return (
+    <section className="space-y-4">
+      <header>
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Finance</h2>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          Set the cash assumptions that feed every financial plan.
+        </p>
+      </header>
+      <BusinessParametersPanel parameters={parameters} />
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- surface the finance business parameters inside the product setup context pane with a dedicated Finance section
- reuse the existing parameter formatting when loading product setup data and stop rendering the panel on the P&L sheet

## Testing
- pnpm lint *(fails: next lint prompts for configuration in apps/margin-master)*
- pnpm --filter @ecom-os/x-plan lint *(fails: missing next binary because workspace deps cannot be installed)*
- pnpm --filter @ecom-os/x-plan type-check *(fails: missing workspace dependencies such as react/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68d359e592448321b2b11316b0eafad2