### PR TITLE
ui(x-plan): refresh handsontable workspace

### DIFF
--- a/apps/x-plan/components/grid-legend.tsx
+++ b/apps/x-plan/components/grid-legend.tsx
@@ -1,3 +1,143 @@
+'use client';
+
+import { clsx } from 'clsx';
+import type { ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { Keyboard, PenSquare, Sigma } from 'lucide-react';
+
 export function GridLegend() {
-  return null
+  return (
+    <div className="grid gap-4 lg:grid-cols-[1.7fr,1fr]">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <LegendCard
+          icon={PenSquare}
+          title="Editable drivers"
+          description="Sky-tinted cells accept inputs and autosave moments after you pause typing."
+          accent="bg-gradient-to-br from-sky-500/25 via-blue-500/15 to-transparent"
+          iconAccent="bg-gradient-to-br from-sky-500/20 via-blue-500/20 to-indigo-500/20 text-sky-600 dark:text-sky-200"
+        />
+        <LegendCard
+          icon={Sigma}
+          title="Calculated outputs"
+          description="Slate cells stay read-only—X-Plan recalculates them from your supply, demand, and finance models."
+          accent="bg-gradient-to-br from-slate-500/20 via-slate-500/10 to-transparent"
+          iconAccent="bg-gradient-to-br from-slate-500/20 via-slate-500/10 to-slate-700/10 text-slate-600 dark:text-slate-200"
+        />
+      </div>
+      <ShortcutCard />
+    </div>
+  );
+}
+
+interface LegendCardProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  accent: string;
+  iconAccent: string;
+}
+
+function LegendCard({ icon: Icon, title, description, accent, iconAccent }: LegendCardProps) {
+  return (
+    <article className="group relative overflow-hidden rounded-2xl border border-slate-200/70 bg-white/80 p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-xl dark:border-white/10 dark:bg-slate-950/40">
+      <div
+        aria-hidden
+        className={clsx(
+          'pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-500 group-hover:opacity-100',
+          accent,
+        )}
+      />
+      <div className="relative z-10 flex items-start gap-3">
+        <span
+          className={clsx(
+            'flex h-10 w-10 items-center justify-center rounded-xl border border-white/70 shadow-sm dark:border-white/10',
+            iconAccent,
+          )}
+        >
+          <Icon className="h-5 w-5" strokeWidth={1.6} />
+        </span>
+        <div className="space-y-1">
+          <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">{title}</p>
+          <p className="text-xs leading-5 text-slate-500 dark:text-slate-400">{description}</p>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function ShortcutCard() {
+  return (
+    <article className="group relative overflow-hidden rounded-2xl border border-slate-200/70 bg-white/80 p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-xl dark:border-white/10 dark:bg-slate-950/40">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-500 group-hover:opacity-100 bg-gradient-to-br from-violet-500/20 via-purple-500/15 to-sky-500/10"
+      />
+      <div className="relative z-10 space-y-4">
+        <div className="flex items-start gap-3">
+          <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-white/70 bg-gradient-to-br from-violet-500/20 via-purple-500/20 to-indigo-500/20 text-indigo-600 shadow-sm dark:border-white/10 dark:text-indigo-200">
+            <Keyboard className="h-5 w-5" strokeWidth={1.6} />
+          </span>
+          <div className="space-y-1">
+            <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">Stay in flow</p>
+            <p className="text-xs leading-5 text-slate-500 dark:text-slate-400">
+              A soft indigo glow tracks the active row. Keep hands on the keyboard to power through
+              updates.
+            </p>
+          </div>
+        </div>
+        <div className="rounded-xl border border-violet-400/30 bg-gradient-to-r from-violet-500/15 via-purple-500/10 to-transparent p-3 text-xs text-violet-700 shadow-inner dark:border-violet-400/30 dark:from-violet-500/20 dark:via-purple-500/15 dark:text-violet-200">
+          <p className="font-semibold">Row focus preview</p>
+          <p className="mt-1 text-[0.7rem] leading-5 text-violet-600/80 dark:text-violet-200/80">
+            Click or arrow into a line to spotlight it—no more guessing which purchase order is
+            live.
+          </p>
+        </div>
+        <dl className="space-y-2 text-xs text-slate-500 dark:text-slate-400">
+          <ShortcutRow description="Edit or commit cell">
+            <Keycap>Enter</Keycap>
+          </ShortcutRow>
+          <ShortcutRow description="Move sideways">
+            <Keycap>Tab</Keycap>
+            <span className="text-slate-400">/</span>
+            <Keycap>⇧ Tab</Keycap>
+          </ShortcutRow>
+          <ShortcutRow description="Switch sheets">
+            <Keycap>Ctrl / ⌘</Keycap>
+            <span className="text-slate-400">+</span>
+            <Keycap>PgUp</Keycap>
+            <span className="text-slate-400">or</span>
+            <Keycap>PgDn</Keycap>
+          </ShortcutRow>
+        </dl>
+      </div>
+    </article>
+  );
+}
+
+interface ShortcutRowProps {
+  children: ReactNode;
+  description: string;
+}
+
+function ShortcutRow({ children, description }: ShortcutRowProps) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2">
+      <dt className="flex flex-wrap items-center gap-1.5 text-slate-600 dark:text-slate-300">
+        {children}
+      </dt>
+      <dd className="text-right text-slate-500 dark:text-slate-400 sm:text-left">{description}</dd>
+    </div>
+  );
+}
+
+interface KeycapProps {
+  children: ReactNode;
+}
+
+function Keycap({ children }: KeycapProps) {
+  return (
+    <span className="inline-flex min-w-[2.5rem] items-center justify-center rounded-md border border-slate-300/60 bg-white/90 px-2 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200">
+      {children}
+    </span>
+  );
 }

--- a/apps/x-plan/components/grid-surface.tsx
+++ b/apps/x-plan/components/grid-surface.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { clsx } from 'clsx';
+import type { HTMLAttributes } from 'react';
+
+interface GridSurfaceProps extends HTMLAttributes<HTMLDivElement> {
+  contentClassName?: string;
+}
+
+export function GridSurface({ children, className, contentClassName, ...props }: GridSurfaceProps) {
+  return (
+    <div
+      {...props}
+      className={clsx(
+        'x-plan-grid-surface relative overflow-hidden rounded-3xl border border-slate-200/60 bg-gradient-to-br from-white/95 via-slate-50/95 to-slate-100/80 shadow-[0_30px_60px_-45px_rgba(15,23,42,0.35)] backdrop-blur-sm dark:border-white/10 dark:from-slate-950/85 dark:via-slate-900/80 dark:to-slate-950/70 dark:shadow-[0_40px_70px_-45px_rgba(15,23,42,0.9)]',
+        className,
+      )}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -top-32 right-[-10%] h-72 w-72 rounded-full bg-gradient-to-br from-purple-500/25 via-blue-500/20 to-transparent blur-3xl"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -bottom-40 left-[-5%] h-80 w-80 rounded-full bg-gradient-to-br from-cyan-400/25 via-sky-500/15 to-transparent blur-3xl"
+      />
+      <div className={clsx('relative z-10 flex flex-col gap-6 p-6 sm:p-8', contentClassName)}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/x-plan/components/sheets/fin-planning-cash-grid.tsx
+++ b/apps/x-plan/components/sheets/fin-planning-cash-grid.tsx
@@ -1,68 +1,69 @@
-'use client'
+'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { HotTable } from '@handsontable/react'
-import Handsontable from 'handsontable'
-import { registerAllModules } from 'handsontable/registry'
-import 'handsontable/dist/handsontable.full.min.css'
-import '@/styles/handsontable-theme.css'
-import { toast } from 'sonner'
-import { GridLegend } from '@/components/grid-legend'
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react';
+import Handsontable from 'handsontable';
+import { registerAllModules } from 'handsontable/registry';
+import 'handsontable/dist/handsontable.full.min.css';
+import '@/styles/handsontable-theme.css';
+import { toast } from 'sonner';
+import { GridLegend } from '@/components/grid-legend';
+import { GridSurface } from '@/components/grid-surface';
 
-registerAllModules()
+registerAllModules();
 
 type WeeklyRow = {
-  weekNumber: string
-  weekDate: string
-  amazonPayout: string
-  inventorySpend: string
-  fixedCosts: string
-  netCash: string
-  cashBalance: string
-}
+  weekNumber: string;
+  weekDate: string;
+  amazonPayout: string;
+  inventorySpend: string;
+  fixedCosts: string;
+  netCash: string;
+  cashBalance: string;
+};
 
 type SummaryRow = {
-  periodLabel: string
-  amazonPayout?: string
-  inventorySpend?: string
-  fixedCosts?: string
-  netCash?: string
-  closingCash?: string
-}
+  periodLabel: string;
+  amazonPayout?: string;
+  inventorySpend?: string;
+  fixedCosts?: string;
+  netCash?: string;
+  closingCash?: string;
+};
 
 type UpdatePayload = {
-  weekNumber: number
-  values: Partial<Record<keyof WeeklyRow, string>>
-}
+  weekNumber: number;
+  values: Partial<Record<keyof WeeklyRow, string>>;
+};
 
 interface CashFlowGridProps {
-  weekly: WeeklyRow[]
-  monthlySummary: SummaryRow[]
-  quarterlySummary: SummaryRow[]
+  weekly: WeeklyRow[];
+  monthlySummary: SummaryRow[];
+  quarterlySummary: SummaryRow[];
 }
 
-const editableFields: (keyof WeeklyRow)[] = ['amazonPayout', 'inventorySpend', 'fixedCosts']
+const editableFields: (keyof WeeklyRow)[] = ['amazonPayout', 'inventorySpend', 'fixedCosts'];
 
 function normalizeEditable(value: unknown) {
-  if (value === '' || value === null || value === undefined) return ''
-  const numeric = Number(value)
-  if (Number.isNaN(numeric)) return String(value ?? '')
-  return numeric.toFixed(2)
+  if (value === '' || value === null || value === undefined) return '';
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) return String(value ?? '');
+  return numeric.toFixed(2);
 }
 
 export function CashFlowGrid({ weekly, monthlySummary, quarterlySummary }: CashFlowGridProps) {
-  const hotRef = useRef<Handsontable | null>(null)
-  const pendingRef = useRef<Map<number, UpdatePayload>>(new Map())
-  const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const [showSummary, setShowSummary] = useState(true)
+  const hotRef = useRef<Handsontable | null>(null);
+  const pendingRef = useRef<Map<number, UpdatePayload>>(new Map());
+  const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [showSummary, setShowSummary] = useState(true);
 
-  const data = useMemo(() => weekly, [weekly])
+  const data = useMemo(() => weekly, [weekly]);
 
   useEffect(() => {
     if (hotRef.current) {
-      hotRef.current.loadData(data)
+      hotRef.current.loadData(data);
     }
-  }, [data])
+  }, [data]);
 
   const columns: Handsontable.ColumnSettings[] = useMemo(
     () => [
@@ -89,88 +90,122 @@ export function CashFlowGrid({ weekly, monthlySummary, quarterlySummary }: CashF
         readOnly: !editableFields.includes('fixedCosts'),
         className: editableFields.includes('fixedCosts') ? 'cell-editable' : 'cell-readonly',
       },
-      { data: 'netCash', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, readOnly: true, className: 'cell-readonly' },
-      { data: 'cashBalance', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, readOnly: true, className: 'cell-readonly' },
+      {
+        data: 'netCash',
+        type: 'numeric',
+        numericFormat: { pattern: '$0,0.00' },
+        readOnly: true,
+        className: 'cell-readonly',
+      },
+      {
+        data: 'cashBalance',
+        type: 'numeric',
+        numericFormat: { pattern: '$0,0.00' },
+        readOnly: true,
+        className: 'cell-readonly',
+      },
     ],
-    []
-  )
+    [],
+  );
 
   const flush = () => {
-    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current)
+    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current);
     flushTimeoutRef.current = setTimeout(async () => {
-      const payload = Array.from(pendingRef.current.values())
-      if (payload.length === 0) return
-      pendingRef.current.clear()
+      const payload = Array.from(pendingRef.current.values());
+      if (payload.length === 0) return;
+      pendingRef.current.clear();
       try {
         const res = await fetch('/api/v1/x-plan/cash-flow', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ updates: payload }),
-        })
-        if (!res.ok) throw new Error('Failed to update cash flow')
-        toast.success('Cash flow updated')
+        });
+        if (!res.ok) throw new Error('Failed to update cash flow');
+        toast.success('Cash flow updated');
       } catch (error) {
-        console.error(error)
-        toast.error('Unable to save cash flow changes')
+        console.error(error);
+        toast.error('Unable to save cash flow changes');
       }
-    }, 600)
-  }
+    }, 600);
+  };
 
   return (
-    <div className="space-y-6 p-4">
-      <div className="space-y-4">
-        <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div>
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              5. Fin Planning Cash Flow
+    <div className="space-y-6">
+      <GridSurface>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Step 5
+            </p>
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-50">
+              Cash Flow Simulator
             </h2>
-            <p className="text-xs text-slate-500 dark:text-slate-400">
-              Update cash drivers; derived net cash and balance cells update automatically.
+            <p className="max-w-3xl text-sm text-slate-500 dark:text-slate-400">
+              Adjust weekly cash drivers and watch net cash plus ending balance recalculate in real
+              time. Layer on payouts, inventory receipts, and fixed costs to stress test upcoming
+              liquidity.
             </p>
           </div>
           <button
             onClick={() => setShowSummary((prev) => !prev)}
-            className="self-start rounded-md border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+            className="inline-flex items-center justify-center rounded-xl border border-slate-300/70 bg-white/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-600 shadow-sm transition hover:border-purple-400/60 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-purple-400/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-purple-400/40"
           >
             {showSummary ? 'Hide rollups' : 'Show rollups'}
           </button>
         </div>
+
         <GridLegend />
-        <HotTable
-          ref={(instance) => {
-            hotRef.current = instance?.hotInstance ?? null
-          }}
-          data={data}
-          licenseKey="non-commercial-and-evaluation"
-          columns={columns}
-          colHeaders={['Week', 'Date', 'Amazon Payout', 'Inventory Purchase', 'Fixed Costs', 'Net Cash', 'Cash Balance']}
-          rowHeaders={false}
-          stretchH="all"
-          className="x-plan-hot"
-          height="auto"
-          dropdownMenu
-          filters
-          afterChange={(changes, source) => {
-            if (!changes || source === 'loadData') return
-            const hot = hotRef.current
-            if (!hot) return
-            for (const change of changes) {
-              const [rowIndex, prop, _oldValue, newValue] = change as [number, keyof WeeklyRow, any, any]
-              if (!editableFields.includes(prop)) continue
-              const record = hot.getSourceDataAtRow(rowIndex) as WeeklyRow | null
-              if (!record) continue
-              const weekNumber = Number(record.weekNumber)
-              if (!pendingRef.current.has(weekNumber)) {
-                pendingRef.current.set(weekNumber, { weekNumber, values: {} })
+
+        <div className="x-plan-grid-shell">
+          <HotTable
+            ref={(instance) => {
+              hotRef.current = instance?.hotInstance ?? null;
+            }}
+            data={data}
+            licenseKey="non-commercial-and-evaluation"
+            columns={columns}
+            colHeaders={[
+              'Week',
+              'Date',
+              'Amazon Payout',
+              'Inventory Purchase',
+              'Fixed Costs',
+              'Net Cash',
+              'Cash Balance',
+            ]}
+            rowHeaders={false}
+            stretchH="all"
+            className="x-plan-hot"
+            height="auto"
+            dropdownMenu
+            filters
+            afterChange={(changes, source) => {
+              if (!changes || source === 'loadData') return;
+              const hot = hotRef.current;
+              if (!hot) return;
+              for (const change of changes) {
+                const [rowIndex, prop, _oldValue, newValue] = change as [
+                  number,
+                  keyof WeeklyRow,
+                  any,
+                  any,
+                ];
+                if (!editableFields.includes(prop)) continue;
+                const record = hot.getSourceDataAtRow(rowIndex) as WeeklyRow | null;
+                if (!record) continue;
+                const weekNumber = Number(record.weekNumber);
+                if (!pendingRef.current.has(weekNumber)) {
+                  pendingRef.current.set(weekNumber, { weekNumber, values: {} });
+                }
+                const entry = pendingRef.current.get(weekNumber);
+                if (!entry) continue;
+                entry.values[prop] = normalizeEditable(newValue);
               }
-            const entry = pendingRef.current.get(weekNumber)
-            if (!entry) continue
-            entry.values[prop] = normalizeEditable(newValue)
-          }
-          flush()
-        }}
-      />
-      </div>
+              flush();
+            }}
+          />
+        </div>
+      </GridSurface>
 
       {showSummary && (
         <div className="grid gap-4 md:grid-cols-2">
@@ -179,32 +214,44 @@ export function CashFlowGrid({ weekly, monthlySummary, quarterlySummary }: CashF
         </div>
       )}
     </div>
-  )
+  );
 }
 
 function CashSummaryTable({ title, rows }: { title: string; rows: SummaryRow[] }) {
-  const headers = ['Period', 'Amazon Payout', 'Inventory Purchase', 'Fixed Costs', 'Net Cash', 'Closing Cash']
+  const headers = [
+    'Period',
+    'Amazon Payout',
+    'Inventory Purchase',
+    'Fixed Costs',
+    'Net Cash',
+    'Closing Cash',
+  ];
   const formatValue = (value?: string) => {
-    if (!value) return ''
-    const numeric = Number(value)
-    if (Number.isNaN(numeric)) return value
-    return numeric.toFixed(2)
-  }
+    if (!value) return '';
+    const numeric = Number(value);
+    if (Number.isNaN(numeric)) return value;
+    return numeric.toFixed(2);
+  };
   return (
-    <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{title}</h3>
+    <section className="rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white/95 via-slate-50/90 to-slate-100/80 p-5 shadow-[0_20px_40px_-35px_rgba(15,23,42,0.45)] backdrop-blur-sm dark:border-white/10 dark:from-slate-950/80 dark:via-slate-900/70 dark:to-slate-950/60 dark:shadow-[0_30px_50px_-40px_rgba(15,23,42,0.85)]">
+      <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
+        {title}
+      </h3>
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
-          <thead className="bg-slate-50 text-xs uppercase dark:bg-slate-800">
+        <table className="min-w-full divide-y divide-slate-200/70 text-sm dark:divide-slate-800/80">
+          <thead className="bg-slate-50/80 text-xs uppercase backdrop-blur-sm dark:bg-slate-900/60">
             <tr>
               {headers.map((header) => (
-                <th key={header} className="px-3 py-2 text-left font-semibold tracking-wide text-slate-500 dark:text-slate-400">
+                <th
+                  key={header}
+                  className="px-3 py-2 text-left font-semibold tracking-wide text-slate-500 dark:text-slate-300"
+                >
                   {header}
                 </th>
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+          <tbody className="divide-y divide-slate-100/70 dark:divide-slate-800/70">
             {rows.map((row) => (
               <tr key={row.periodLabel} className="text-slate-700 dark:text-slate-200">
                 <td className="px-3 py-2 font-medium">{row.periodLabel}</td>
@@ -219,5 +266,5 @@ function CashSummaryTable({ title, rows }: { title: string; rows: SummaryRow[] }
         </table>
       </div>
     </section>
-  )
+  );
 }

--- a/apps/x-plan/components/sheets/fin-planning-pl-grid.tsx
+++ b/apps/x-plan/components/sheets/fin-planning-pl-grid.tsx
@@ -1,80 +1,92 @@
-'use client'
+'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { HotTable } from '@handsontable/react'
-import Handsontable from 'handsontable'
-import { registerAllModules } from 'handsontable/registry'
-import 'handsontable/dist/handsontable.full.min.css'
-import '@/styles/handsontable-theme.css'
-import { toast } from 'sonner'
-import { GridLegend } from '@/components/grid-legend'
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react';
+import Handsontable from 'handsontable';
+import { registerAllModules } from 'handsontable/registry';
+import 'handsontable/dist/handsontable.full.min.css';
+import '@/styles/handsontable-theme.css';
+import { toast } from 'sonner';
+import { GridLegend } from '@/components/grid-legend';
+import { GridSurface } from '@/components/grid-surface';
 
-registerAllModules()
+registerAllModules();
 
 type WeeklyRow = {
-  weekNumber: string
-  weekDate: string
-  units: string
-  revenue: string
-  cogs: string
-  grossProfit: string
-  grossMargin: string
-  amazonFees: string
-  ppcSpend: string
-  fixedCosts: string
-  totalOpex: string
-  netProfit: string
-}
+  weekNumber: string;
+  weekDate: string;
+  units: string;
+  revenue: string;
+  cogs: string;
+  grossProfit: string;
+  grossMargin: string;
+  amazonFees: string;
+  ppcSpend: string;
+  fixedCosts: string;
+  totalOpex: string;
+  netProfit: string;
+};
 
 type SummaryRow = {
-  periodLabel: string
-  revenue?: string
-  cogs?: string
-  grossProfit?: string
-  amazonFees?: string
-  ppcSpend?: string
-  fixedCosts?: string
-  totalOpex?: string
-  netProfit?: string
-  amazonPayout?: string
-  inventorySpend?: string
-  netCash?: string
-  closingCash?: string
-}
+  periodLabel: string;
+  revenue?: string;
+  cogs?: string;
+  grossProfit?: string;
+  amazonFees?: string;
+  ppcSpend?: string;
+  fixedCosts?: string;
+  totalOpex?: string;
+  netProfit?: string;
+  amazonPayout?: string;
+  inventorySpend?: string;
+  netCash?: string;
+  closingCash?: string;
+};
 
 type UpdatePayload = {
-  weekNumber: number
-  values: Partial<Record<keyof WeeklyRow, string>>
-}
+  weekNumber: number;
+  values: Partial<Record<keyof WeeklyRow, string>>;
+};
 
 interface ProfitAndLossGridProps {
-  weekly: WeeklyRow[]
-  monthlySummary: SummaryRow[]
-  quarterlySummary: SummaryRow[]
+  weekly: WeeklyRow[];
+  monthlySummary: SummaryRow[];
+  quarterlySummary: SummaryRow[];
 }
 
-const editableFields: (keyof WeeklyRow)[] = ['units', 'revenue', 'cogs', 'amazonFees', 'ppcSpend', 'fixedCosts']
+const editableFields: (keyof WeeklyRow)[] = [
+  'units',
+  'revenue',
+  'cogs',
+  'amazonFees',
+  'ppcSpend',
+  'fixedCosts',
+];
 
 function normalizeEditable(value: unknown) {
-  if (value === '' || value === null || value === undefined) return ''
-  const numeric = Number(value)
-  if (Number.isNaN(numeric)) return String(value ?? '')
-  return numeric.toFixed(2)
+  if (value === '' || value === null || value === undefined) return '';
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) return String(value ?? '');
+  return numeric.toFixed(2);
 }
 
-export function ProfitAndLossGrid({ weekly, monthlySummary, quarterlySummary }: ProfitAndLossGridProps) {
-  const hotRef = useRef<Handsontable | null>(null)
-  const pendingRef = useRef<Map<number, UpdatePayload>>(new Map())
-  const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const [showSummary, setShowSummary] = useState(true)
+export function ProfitAndLossGrid({
+  weekly,
+  monthlySummary,
+  quarterlySummary,
+}: ProfitAndLossGridProps) {
+  const hotRef = useRef<Handsontable | null>(null);
+  const pendingRef = useRef<Map<number, UpdatePayload>>(new Map());
+  const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [showSummary, setShowSummary] = useState(true);
 
-  const data = useMemo(() => weekly, [weekly])
+  const data = useMemo(() => weekly, [weekly]);
 
   useEffect(() => {
     if (hotRef.current) {
-      hotRef.current.loadData(data)
+      hotRef.current.loadData(data);
     }
-  }, [data])
+  }, [data]);
 
   const columns: Handsontable.ColumnSettings[] = useMemo(
     () => [
@@ -101,8 +113,20 @@ export function ProfitAndLossGrid({ weekly, monthlySummary, quarterlySummary }: 
         readOnly: !editableFields.includes('cogs'),
         className: editableFields.includes('cogs') ? 'cell-editable' : 'cell-readonly',
       },
-      { data: 'grossProfit', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, readOnly: true, className: 'cell-readonly' },
-      { data: 'grossMargin', type: 'numeric', numericFormat: { pattern: '0.00%' }, readOnly: true, className: 'cell-readonly' },
+      {
+        data: 'grossProfit',
+        type: 'numeric',
+        numericFormat: { pattern: '$0,0.00' },
+        readOnly: true,
+        className: 'cell-readonly',
+      },
+      {
+        data: 'grossMargin',
+        type: 'numeric',
+        numericFormat: { pattern: '0.00%' },
+        readOnly: true,
+        className: 'cell-readonly',
+      },
       {
         data: 'amazonFees',
         type: 'numeric',
@@ -124,88 +148,127 @@ export function ProfitAndLossGrid({ weekly, monthlySummary, quarterlySummary }: 
         readOnly: !editableFields.includes('fixedCosts'),
         className: editableFields.includes('fixedCosts') ? 'cell-editable' : 'cell-readonly',
       },
-      { data: 'totalOpex', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, readOnly: true, className: 'cell-readonly' },
-      { data: 'netProfit', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, readOnly: true, className: 'cell-readonly' },
+      {
+        data: 'totalOpex',
+        type: 'numeric',
+        numericFormat: { pattern: '$0,0.00' },
+        readOnly: true,
+        className: 'cell-readonly',
+      },
+      {
+        data: 'netProfit',
+        type: 'numeric',
+        numericFormat: { pattern: '$0,0.00' },
+        readOnly: true,
+        className: 'cell-readonly',
+      },
     ],
-    []
-  )
+    [],
+  );
 
   const flush = () => {
-    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current)
+    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current);
     flushTimeoutRef.current = setTimeout(async () => {
-      const payload = Array.from(pendingRef.current.values())
-      if (payload.length === 0) return
-      pendingRef.current.clear()
+      const payload = Array.from(pendingRef.current.values());
+      if (payload.length === 0) return;
+      pendingRef.current.clear();
       try {
         const res = await fetch('/api/v1/x-plan/profit-and-loss', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ updates: payload }),
-        })
-        if (!res.ok) throw new Error('Failed to update P&L')
-        toast.success('P&L updated')
+        });
+        if (!res.ok) throw new Error('Failed to update P&L');
+        toast.success('P&L updated');
       } catch (error) {
-        console.error(error)
-        toast.error('Unable to save P&L changes')
+        console.error(error);
+        toast.error('Unable to save P&L changes');
       }
-    }, 600)
-  }
+    }, 600);
+  };
 
   return (
-    <div className="space-y-6 p-4">
-      <div className="space-y-4">
-        <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div>
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              4. Fin Planning P&amp;L
+    <div className="space-y-6">
+      <GridSurface>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Step 4
+            </p>
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-50">
+              Weekly Profit &amp; Loss
             </h2>
-            <p className="text-xs text-slate-500 dark:text-slate-400">
-              Only edit blue driver cells—grey results roll up automatically from calculations.
+            <p className="max-w-3xl text-sm text-slate-500 dark:text-slate-400">
+              Enter demand, revenue, and spend assumptions. The grey outputs consolidate
+              contribution margin, operating expense, and net income so you can pressure test
+              scenarios without leaving the sheet.
             </p>
           </div>
           <button
             onClick={() => setShowSummary((prev) => !prev)}
-            className="self-start rounded-md border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+            className="inline-flex items-center justify-center rounded-xl border border-slate-300/70 bg-white/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-600 shadow-sm transition hover:border-purple-400/60 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-purple-400/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-purple-400/40"
           >
             {showSummary ? 'Hide rollups' : 'Show rollups'}
           </button>
         </div>
+
         <GridLegend />
-        <HotTable
-          ref={(instance) => {
-            hotRef.current = instance?.hotInstance ?? null
-          }}
-          data={data}
-          licenseKey="non-commercial-and-evaluation"
-          columns={columns}
-          colHeaders={['Week', 'Date', 'Units', 'Revenue', 'COGS', 'Gross Profit', 'GP%', 'Amazon Fees', 'PPC', 'Fixed Costs', 'Total OpEx', 'Net Profit']}
-          rowHeaders={false}
-          stretchH="all"
-          className="x-plan-hot"
-          height="auto"
-          dropdownMenu
-          filters
-          afterChange={(changes, source) => {
-            if (!changes || source === 'loadData') return
-            const hot = hotRef.current
-            if (!hot) return
-            for (const change of changes) {
-              const [rowIndex, prop, _oldValue, newValue] = change as [number, keyof WeeklyRow, any, any]
-              if (!editableFields.includes(prop)) continue
-              const record = hot.getSourceDataAtRow(rowIndex) as WeeklyRow | null
-              if (!record) continue
-              const weekNumber = Number(record.weekNumber)
-              if (!pendingRef.current.has(weekNumber)) {
-                pendingRef.current.set(weekNumber, { weekNumber, values: {} })
+
+        <div className="x-plan-grid-shell">
+          <HotTable
+            ref={(instance) => {
+              hotRef.current = instance?.hotInstance ?? null;
+            }}
+            data={data}
+            licenseKey="non-commercial-and-evaluation"
+            columns={columns}
+            colHeaders={[
+              'Week',
+              'Date',
+              'Units',
+              'Revenue',
+              'COGS',
+              'Gross Profit',
+              'GP%',
+              'Amazon Fees',
+              'PPC',
+              'Fixed Costs',
+              'Total OpEx',
+              'Net Profit',
+            ]}
+            rowHeaders={false}
+            stretchH="all"
+            className="x-plan-hot"
+            height="auto"
+            dropdownMenu
+            filters
+            afterChange={(changes, source) => {
+              if (!changes || source === 'loadData') return;
+              const hot = hotRef.current;
+              if (!hot) return;
+              for (const change of changes) {
+                const [rowIndex, prop, _oldValue, newValue] = change as [
+                  number,
+                  keyof WeeklyRow,
+                  any,
+                  any,
+                ];
+                if (!editableFields.includes(prop)) continue;
+                const record = hot.getSourceDataAtRow(rowIndex) as WeeklyRow | null;
+                if (!record) continue;
+                const weekNumber = Number(record.weekNumber);
+                if (!pendingRef.current.has(weekNumber)) {
+                  pendingRef.current.set(weekNumber, { weekNumber, values: {} });
+                }
+                const entry = pendingRef.current.get(weekNumber);
+                if (!entry) continue;
+                entry.values[prop] = normalizeEditable(newValue);
               }
-            const entry = pendingRef.current.get(weekNumber)
-            if (!entry) continue
-            entry.values[prop] = normalizeEditable(newValue)
-          }
-          flush()
-        }}
-      />
-      </div>
+              flush();
+            }}
+          />
+        </div>
+      </GridSurface>
 
       {showSummary && (
         <div className="grid gap-4 md:grid-cols-2">
@@ -214,34 +277,49 @@ export function ProfitAndLossGrid({ weekly, monthlySummary, quarterlySummary }: 
         </div>
       )}
     </div>
-  )
+  );
 }
 
 function SummaryTable({ title, rows }: { title: string; rows: SummaryRow[] }) {
-  const headers = ['Period', 'Revenue', 'COGS', 'Gross Profit', 'Amazon Fees', 'PPC', 'Fixed Costs', 'Total OpEx', 'Net Profit']
+  const headers = [
+    'Period',
+    'Revenue',
+    'COGS',
+    'Gross Profit',
+    'Amazon Fees',
+    'PPC',
+    'Fixed Costs',
+    'Total OpEx',
+    'Net Profit',
+  ];
 
   const formatValue = (value?: string) => {
-    if (!value) return ''
-    const numeric = Number(value)
-    if (Number.isNaN(numeric)) return value
-    return numeric.toFixed(2)
-  }
+    if (!value) return '';
+    const numeric = Number(value);
+    if (Number.isNaN(numeric)) return value;
+    return numeric.toFixed(2);
+  };
 
   return (
-    <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{title}</h3>
+    <section className="rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white/95 via-slate-50/90 to-slate-100/80 p-5 shadow-[0_20px_40px_-35px_rgba(15,23,42,0.45)] backdrop-blur-sm dark:border-white/10 dark:from-slate-950/80 dark:via-slate-900/70 dark:to-slate-950/60 dark:shadow-[0_30px_50px_-40px_rgba(15,23,42,0.85)]">
+      <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
+        {title}
+      </h3>
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
-          <thead className="bg-slate-50 text-xs uppercase dark:bg-slate-800">
+        <table className="min-w-full divide-y divide-slate-200/70 text-sm dark:divide-slate-800/80">
+          <thead className="bg-slate-50/80 text-xs uppercase backdrop-blur-sm dark:bg-slate-900/60">
             <tr>
               {headers.map((header) => (
-                <th key={header} className="px-3 py-2 text-left font-semibold tracking-wide text-slate-500 dark:text-slate-400">
+                <th
+                  key={header}
+                  className="px-3 py-2 text-left font-semibold tracking-wide text-slate-500 dark:text-slate-300"
+                >
                   {header}
                 </th>
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+          <tbody className="divide-y divide-slate-100/70 dark:divide-slate-800/70">
             {rows.map((row) => (
               <tr key={row.periodLabel} className="text-slate-700 dark:text-slate-200">
                 <td className="px-3 py-2 font-medium">{row.periodLabel}</td>
@@ -259,5 +337,5 @@ function SummaryTable({ title, rows }: { title: string; rows: SummaryRow[] }) {
         </table>
       </div>
     </section>
-  )
+  );
 }

--- a/apps/x-plan/components/sheets/ops-planning-cost-grid.tsx
+++ b/apps/x-plan/components/sheets/ops-planning-cost-grid.tsx
@@ -1,21 +1,23 @@
-'use client'
+'use client';
 
-import { useEffect, useMemo, useRef } from 'react'
-import { HotTable } from '@handsontable/react'
-import Handsontable from 'handsontable'
-import { registerAllModules } from 'handsontable/registry'
-import 'handsontable/dist/handsontable.full.min.css'
-import '@/styles/handsontable-theme.css'
-import { toast } from 'sonner'
-import type { OpsInputRow } from '@/components/sheets/ops-planning-grid'
+import { useEffect, useMemo, useRef } from 'react';
+import { HotTable } from '@handsontable/react';
+import Handsontable from 'handsontable';
+import { registerAllModules } from 'handsontable/registry';
+import 'handsontable/dist/handsontable.full.min.css';
+import '@/styles/handsontable-theme.css';
+import { toast } from 'sonner';
+import type { OpsInputRow } from '@/components/sheets/ops-planning-grid';
+import { GridLegend } from '@/components/grid-legend';
+import { GridSurface } from '@/components/grid-surface';
 
-registerAllModules()
+registerAllModules();
 
 interface OpsPlanningCostGridProps {
-  rows: OpsInputRow[]
-  activeOrderId?: string | null
-  onSelectOrder?: (orderId: string) => void
-  onRowsChange?: (rows: OpsInputRow[]) => void
+  rows: OpsInputRow[];
+  activeOrderId?: string | null;
+  onSelectOrder?: (orderId: string) => void;
+  onRowsChange?: (rows: OpsInputRow[]) => void;
 }
 
 const COST_HEADERS = [
@@ -29,20 +31,68 @@ const COST_HEADERS = [
   'FBA $',
   'Referral %',
   'Storage $',
-]
+];
 
 const COST_COLUMNS: Handsontable.ColumnSettings[] = [
   { data: 'orderCode', readOnly: true, className: 'cell-readonly', width: 140 },
   { data: 'productName', readOnly: true, className: 'cell-readonly', width: 180 },
-  { data: 'sellingPrice', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, className: 'cell-editable text-right', width: 120 },
-  { data: 'manufacturingCost', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, className: 'cell-editable text-right', width: 120 },
-  { data: 'freightCost', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, className: 'cell-editable text-right', width: 120 },
-  { data: 'tariffRate', type: 'numeric', numericFormat: { pattern: '0.00%' }, className: 'cell-editable text-right', width: 110 },
-  { data: 'tacosPercent', type: 'numeric', numericFormat: { pattern: '0.00%' }, className: 'cell-editable text-right', width: 110 },
-  { data: 'fbaFee', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, className: 'cell-editable text-right', width: 110 },
-  { data: 'referralRate', type: 'numeric', numericFormat: { pattern: '0.00%' }, className: 'cell-editable text-right', width: 110 },
-  { data: 'storagePerMonth', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, className: 'cell-editable text-right', width: 120 },
-]
+  {
+    data: 'sellingPrice',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0.00' },
+    className: 'cell-editable text-right',
+    width: 120,
+  },
+  {
+    data: 'manufacturingCost',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0.00' },
+    className: 'cell-editable text-right',
+    width: 120,
+  },
+  {
+    data: 'freightCost',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0.00' },
+    className: 'cell-editable text-right',
+    width: 120,
+  },
+  {
+    data: 'tariffRate',
+    type: 'numeric',
+    numericFormat: { pattern: '0.00%' },
+    className: 'cell-editable text-right',
+    width: 110,
+  },
+  {
+    data: 'tacosPercent',
+    type: 'numeric',
+    numericFormat: { pattern: '0.00%' },
+    className: 'cell-editable text-right',
+    width: 110,
+  },
+  {
+    data: 'fbaFee',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0.00' },
+    className: 'cell-editable text-right',
+    width: 110,
+  },
+  {
+    data: 'referralRate',
+    type: 'numeric',
+    numericFormat: { pattern: '0.00%' },
+    className: 'cell-editable text-right',
+    width: 110,
+  },
+  {
+    data: 'storagePerMonth',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0.00' },
+    className: 'cell-editable text-right',
+    width: 120,
+  },
+];
 
 const NUMERIC_PRECISION: Record<string, number> = {
   sellingPrice: 2,
@@ -50,136 +100,170 @@ const NUMERIC_PRECISION: Record<string, number> = {
   freightCost: 2,
   fbaFee: 2,
   storagePerMonth: 2,
-}
+};
 
 const PERCENT_PRECISION: Record<string, number> = {
   tariffRate: 4,
   tacosPercent: 4,
   referralRate: 4,
-}
+};
 
 function normalizeCurrency(value: unknown, fractionDigits = 2) {
-  if (value === '' || value === null || value === undefined) return ''
-  const numeric = Number(value)
-  if (Number.isNaN(numeric)) return String(value ?? '')
-  return numeric.toFixed(fractionDigits)
+  if (value === '' || value === null || value === undefined) return '';
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) return String(value ?? '');
+  return numeric.toFixed(fractionDigits);
 }
 
 function normalizePercent(value: unknown, fractionDigits = 4) {
-  if (value === '' || value === null || value === undefined) return ''
-  const numeric = Number(value)
-  if (Number.isNaN(numeric)) return String(value ?? '')
-  const base = numeric > 1 ? numeric / 100 : numeric
-  return base.toFixed(fractionDigits)
+  if (value === '' || value === null || value === undefined) return '';
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) return String(value ?? '');
+  const base = numeric > 1 ? numeric / 100 : numeric;
+  return base.toFixed(fractionDigits);
 }
 
-export function OpsPlanningCostGrid({ rows, activeOrderId, onSelectOrder, onRowsChange }: OpsPlanningCostGridProps) {
-  const hotRef = useRef<Handsontable | null>(null)
-  const pendingRef = useRef<Map<string, { id: string; values: Record<string, string> }>>(new Map())
-  const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+export function OpsPlanningCostGrid({
+  rows,
+  activeOrderId,
+  onSelectOrder,
+  onRowsChange,
+}: OpsPlanningCostGridProps) {
+  const hotRef = useRef<Handsontable | null>(null);
+  const pendingRef = useRef<Map<string, { id: string; values: Record<string, string> }>>(new Map());
+  const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const data = useMemo(() => rows, [rows])
+  const data = useMemo(() => rows, [rows]);
+
+  const activeOrderLabel = useMemo(() => {
+    if (!activeOrderId) return null;
+    const match = data.find((row) => row.id === activeOrderId);
+    if (!match) return null;
+    return `${match.orderCode ?? 'PO'} • ${match.productName}`;
+  }, [activeOrderId, data]);
 
   useEffect(() => {
     if (hotRef.current) {
-      hotRef.current.loadData(data)
+      hotRef.current.loadData(data);
     }
-  }, [data])
+  }, [data]);
 
   const flush = () => {
-    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current)
+    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current);
     flushTimeoutRef.current = setTimeout(async () => {
-      const payload = Array.from(pendingRef.current.values())
-      if (payload.length === 0) return
-      pendingRef.current.clear()
+      const payload = Array.from(pendingRef.current.values());
+      if (payload.length === 0) return;
+      pendingRef.current.clear();
       try {
         const response = await fetch('/api/v1/x-plan/purchase-orders', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ updates: payload }),
-        })
-        if (!response.ok) throw new Error('Failed to update purchase orders')
-        toast.success('Cost overrides saved')
+        });
+        if (!response.ok) throw new Error('Failed to update purchase orders');
+        toast.success('Cost overrides saved');
       } catch (error) {
-        console.error(error)
-        toast.error('Unable to save cost overrides')
+        console.error(error);
+        toast.error('Unable to save cost overrides');
       }
-    }, 500)
-  }
+    }, 500);
+  };
 
   return (
-    <section className="space-y-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <header className="flex items-center justify-between">
-        <div>
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            Batch Cost Overrides
-          </h2>
-        </div>
-      </header>
-      <HotTable
-        ref={(instance) => {
-          hotRef.current = instance?.hotInstance ?? null
-        }}
-        data={data}
-        licenseKey="non-commercial-and-evaluation"
-        columns={COST_COLUMNS}
-        colHeaders={COST_HEADERS}
-        stretchH="all"
-        className="x-plan-hot"
-        rowHeaders={false}
-        height="auto"
-        dropdownMenu
-        filters
-        cells={(row) => {
-          const meta = {} as Handsontable.CellMeta
-          const record = data[row]
-          if (record && activeOrderId && record.id === activeOrderId) {
-            meta.className = meta.className ? `${meta.className} row-active` : 'row-active'
-          }
-          return meta
-        }}
-        afterSelectionEnd={(row) => {
-          if (!onSelectOrder) return
-          const record = data[row]
-          if (record) onSelectOrder(record.id)
-        }}
-        afterChange={(changes, rawSource) => {
-          if (!changes || rawSource === 'loadData') return
-          const hot = hotRef.current
-          if (!hot) return
+    <GridSurface>
+      <div className="flex flex-col gap-2">
+        <p className="text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-slate-400">
+          Cost overrides
+        </p>
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-50">
+          Unit Economics Guardrails
+        </h2>
+        <p className="max-w-3xl text-sm text-slate-500 dark:text-slate-400">
+          Override the automatically calculated costs when vendors shift pricing. Values feed the
+          P&amp;L immediately, so you can see the profitability impact without leaving the grid.
+        </p>
+        {activeOrderLabel && (
+          <p className="rounded-full border border-slate-300/70 bg-white/80 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-slate-500 shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-300">
+            Editing {activeOrderLabel}
+          </p>
+        )}
+      </div>
 
-          for (const change of changes) {
-            const [rowIndex, prop, _oldValue, newValue] = change as [number, keyof OpsInputRow, any, any]
-            const record = hot.getSourceDataAtRow(rowIndex) as OpsInputRow | null
-            if (!record) continue
+      <GridLegend />
 
-            if (!pendingRef.current.has(record.id)) {
-              pendingRef.current.set(record.id, { id: record.id, values: {} })
+      <div className="x-plan-grid-shell">
+        <HotTable
+          ref={(instance) => {
+            hotRef.current = instance?.hotInstance ?? null;
+          }}
+          data={data}
+          licenseKey="non-commercial-and-evaluation"
+          columns={COST_COLUMNS}
+          colHeaders={COST_HEADERS}
+          stretchH="all"
+          className="x-plan-hot"
+          rowHeaders={false}
+          height="auto"
+          dropdownMenu
+          filters
+          cells={(row) => {
+            const meta = {} as Handsontable.CellMeta;
+            const record = data[row];
+            if (record && activeOrderId && record.id === activeOrderId) {
+              meta.className = meta.className ? `${meta.className} row-active` : 'row-active';
             }
-            const entry = pendingRef.current.get(record.id)
-            if (!entry) continue
+            return meta;
+          }}
+          afterSelectionEnd={(row) => {
+            if (!onSelectOrder) return;
+            const record = data[row];
+            if (record) onSelectOrder(record.id);
+          }}
+          afterChange={(changes, rawSource) => {
+            if (!changes || rawSource === 'loadData') return;
+            const hot = hotRef.current;
+            if (!hot) return;
 
-            if (prop in NUMERIC_PRECISION) {
-              const precision = NUMERIC_PRECISION[prop as keyof typeof NUMERIC_PRECISION]
-              const normalized = normalizeCurrency(newValue, precision)
-              entry.values[prop] = normalized
-              record[prop] = normalized as OpsInputRow[typeof prop]
-            } else if (prop in PERCENT_PRECISION) {
-              const precision = PERCENT_PRECISION[prop as keyof typeof PERCENT_PRECISION]
-              const normalized = normalizePercent(newValue, precision)
-              entry.values[prop] = normalized
-              record[prop] = normalized as OpsInputRow[typeof prop]
+            for (const change of changes) {
+              const [rowIndex, prop, _oldValue, newValue] = change as [
+                number,
+                keyof OpsInputRow,
+                any,
+                any,
+              ];
+              const record = hot.getSourceDataAtRow(rowIndex) as OpsInputRow | null;
+              if (!record) continue;
+
+              if (!pendingRef.current.has(record.id)) {
+                pendingRef.current.set(record.id, { id: record.id, values: {} });
+              }
+              const entry = pendingRef.current.get(record.id);
+              if (!entry) continue;
+
+              if (prop in NUMERIC_PRECISION) {
+                const precision = NUMERIC_PRECISION[prop as keyof typeof NUMERIC_PRECISION];
+                const normalized = normalizeCurrency(newValue, precision);
+                entry.values[prop] = normalized;
+                record[prop] = normalized as OpsInputRow[typeof prop];
+              } else if (prop in PERCENT_PRECISION) {
+                const precision = PERCENT_PRECISION[prop as keyof typeof PERCENT_PRECISION];
+                const normalized = normalizePercent(newValue, precision);
+                entry.values[prop] = normalized;
+                record[prop] = normalized as OpsInputRow[typeof prop];
+              }
             }
-          }
 
-          if (onRowsChange && hotRef.current) {
-            const updated = (hotRef.current.getSourceData() as OpsInputRow[]).map((row) => ({ ...row }))
-            onRowsChange(updated)
-          }
+            if (onRowsChange && hotRef.current) {
+              const updated = (hotRef.current.getSourceData() as OpsInputRow[]).map((row) => ({
+                ...row,
+              }));
+              onRowsChange(updated);
+            }
 
-          flush()
-        }}
-      />
-    </section>
-  )
+            flush();
+          }}
+        />
+      </div>
+    </GridSurface>
+  );
 }

--- a/apps/x-plan/components/sheets/ops-planning-grid.tsx
+++ b/apps/x-plan/components/sheets/ops-planning-grid.tsx
@@ -1,44 +1,45 @@
-'use client'
+'use client';
 
-import { useEffect, useMemo, useRef } from 'react'
-import { HotTable } from '@handsontable/react'
-import Handsontable from 'handsontable'
-import { registerAllModules } from 'handsontable/registry'
-import 'handsontable/dist/handsontable.full.min.css'
-import '@/styles/handsontable-theme.css'
-import { toast } from 'sonner'
-import { GridLegend } from '@/components/grid-legend'
+import { useEffect, useMemo, useRef } from 'react';
+import { HotTable } from '@handsontable/react';
+import Handsontable from 'handsontable';
+import { registerAllModules } from 'handsontable/registry';
+import 'handsontable/dist/handsontable.full.min.css';
+import '@/styles/handsontable-theme.css';
+import { toast } from 'sonner';
+import { GridLegend } from '@/components/grid-legend';
+import { GridSurface } from '@/components/grid-surface';
 
-registerAllModules()
+registerAllModules();
 
 export type OpsInputRow = {
-  id: string
-  productId: string
-  orderCode: string
-  productName: string
-  quantity: string
-  pay1Date: string
-  productionWeeks: string
-  sourcePrepWeeks: string
-  oceanWeeks: string
-  finalMileWeeks: string
-  sellingPrice: string
-  manufacturingCost: string
-  freightCost: string
-  tariffRate: string
-  tacosPercent: string
-  fbaFee: string
-  referralRate: string
-  storagePerMonth: string
-  status: string
-  notes: string
-}
+  id: string;
+  productId: string;
+  orderCode: string;
+  productName: string;
+  quantity: string;
+  pay1Date: string;
+  productionWeeks: string;
+  sourcePrepWeeks: string;
+  oceanWeeks: string;
+  finalMileWeeks: string;
+  sellingPrice: string;
+  manufacturingCost: string;
+  freightCost: string;
+  tariffRate: string;
+  tacosPercent: string;
+  fbaFee: string;
+  referralRate: string;
+  storagePerMonth: string;
+  status: string;
+  notes: string;
+};
 
 interface OpsPlanningGridProps {
-  rows: OpsInputRow[]
-  activeOrderId?: string | null
-  onSelectOrder?: (orderId: string) => void
-  onRowsChange?: (rows: OpsInputRow[]) => void
+  rows: OpsInputRow[];
+  activeOrderId?: string | null;
+  onSelectOrder?: (orderId: string) => void;
+  onRowsChange?: (rows: OpsInputRow[]) => void;
 }
 
 const COLUMN_HEADERS = [
@@ -52,17 +53,54 @@ const COLUMN_HEADERS = [
   'Final (wk)',
   'Status',
   'Notes',
-]
+];
 
 const COLUMN_SETTINGS: Handsontable.ColumnSettings[] = [
   { data: 'orderCode', className: 'cell-editable', width: 150 },
   { data: 'productName', readOnly: true, className: 'cell-readonly', width: 200 },
-  { data: 'quantity', type: 'numeric', numericFormat: { pattern: '0,0' }, className: 'cell-editable text-right', width: 110 },
-  { data: 'pay1Date', type: 'date', dateFormat: 'MMM D YYYY', correctFormat: true, className: 'cell-editable', width: 150 },
-  { data: 'productionWeeks', type: 'numeric', numericFormat: { pattern: '0.00' }, className: 'cell-editable text-right', width: 120 },
-  { data: 'sourcePrepWeeks', type: 'numeric', numericFormat: { pattern: '0.00' }, className: 'cell-editable text-right', width: 120 },
-  { data: 'oceanWeeks', type: 'numeric', numericFormat: { pattern: '0.00' }, className: 'cell-editable text-right', width: 120 },
-  { data: 'finalMileWeeks', type: 'numeric', numericFormat: { pattern: '0.00' }, className: 'cell-editable text-right', width: 120 },
+  {
+    data: 'quantity',
+    type: 'numeric',
+    numericFormat: { pattern: '0,0' },
+    className: 'cell-editable text-right',
+    width: 110,
+  },
+  {
+    data: 'pay1Date',
+    type: 'date',
+    dateFormat: 'MMM D YYYY',
+    correctFormat: true,
+    className: 'cell-editable',
+    width: 150,
+  },
+  {
+    data: 'productionWeeks',
+    type: 'numeric',
+    numericFormat: { pattern: '0.00' },
+    className: 'cell-editable text-right',
+    width: 120,
+  },
+  {
+    data: 'sourcePrepWeeks',
+    type: 'numeric',
+    numericFormat: { pattern: '0.00' },
+    className: 'cell-editable text-right',
+    width: 120,
+  },
+  {
+    data: 'oceanWeeks',
+    type: 'numeric',
+    numericFormat: { pattern: '0.00' },
+    className: 'cell-editable text-right',
+    width: 120,
+  },
+  {
+    data: 'finalMileWeeks',
+    type: 'numeric',
+    numericFormat: { pattern: '0.00' },
+    className: 'cell-editable text-right',
+    width: 120,
+  },
   {
     data: 'status',
     type: 'dropdown',
@@ -73,7 +111,7 @@ const COLUMN_SETTINGS: Handsontable.ColumnSettings[] = [
     width: 130,
   },
   { data: 'notes', className: 'cell-editable', width: 200 },
-]
+];
 
 const NUMERIC_PRECISION: Partial<Record<keyof OpsInputRow, number>> = {
   quantity: 0,
@@ -89,7 +127,7 @@ const NUMERIC_PRECISION: Partial<Record<keyof OpsInputRow, number>> = {
   fbaFee: 2,
   referralRate: 4,
   storagePerMonth: 2,
-}
+};
 
 const NUMERIC_FIELDS = new Set<keyof OpsInputRow>([
   'quantity',
@@ -105,122 +143,186 @@ const NUMERIC_FIELDS = new Set<keyof OpsInputRow>([
   'fbaFee',
   'referralRate',
   'storagePerMonth',
-])
-const DATE_FIELDS = new Set<keyof OpsInputRow>(['pay1Date'])
+]);
+const DATE_FIELDS = new Set<keyof OpsInputRow>(['pay1Date']);
 
 function normalizeNumeric(value: unknown, fractionDigits = 2) {
-  if (value === '' || value === null || value === undefined) return ''
-  const numeric = Number(value)
-  if (Number.isNaN(numeric)) return String(value ?? '')
-  return numeric.toFixed(fractionDigits)
+  if (value === '' || value === null || value === undefined) return '';
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) return String(value ?? '');
+  return numeric.toFixed(fractionDigits);
 }
 
-export function OpsPlanningGrid({ rows, activeOrderId, onSelectOrder, onRowsChange }: OpsPlanningGridProps) {
-  const hotRef = useRef<Handsontable | null>(null)
-  const pendingRef = useRef<Map<string, { id: string; values: Record<string, string> }>>(new Map())
-  const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+export function OpsPlanningGrid({
+  rows,
+  activeOrderId,
+  onSelectOrder,
+  onRowsChange,
+}: OpsPlanningGridProps) {
+  const hotRef = useRef<Handsontable | null>(null);
+  const pendingRef = useRef<Map<string, { id: string; values: Record<string, string> }>>(new Map());
+  const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const data = useMemo(() => rows, [rows])
+  const data = useMemo(() => rows, [rows]);
+
+  const metrics = useMemo(() => {
+    const orderCount = data.length;
+    let totalUnits = 0;
+    for (const row of data) {
+      totalUnits += Number(row.quantity ?? 0);
+    }
+    const formattedUnits = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(
+      totalUnits,
+    );
+    return { orderCount, formattedUnits };
+  }, [data]);
+
+  const activeOrderLabel = useMemo(() => {
+    if (!activeOrderId) return 'No selection';
+    const match = data.find((row) => row.id === activeOrderId);
+    if (!match) return 'No selection';
+    return `${match.orderCode ?? 'PO'} • ${match.productName}`;
+  }, [activeOrderId, data]);
 
   useEffect(() => {
     if (hotRef.current) {
-      hotRef.current.loadData(data)
+      hotRef.current.loadData(data);
     }
-  }, [data])
+  }, [data]);
 
   const flush = () => {
-    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current)
+    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current);
     flushTimeoutRef.current = setTimeout(async () => {
-      const payload = Array.from(pendingRef.current.values())
-      if (payload.length === 0) return
-      pendingRef.current.clear()
+      const payload = Array.from(pendingRef.current.values());
+      if (payload.length === 0) return;
+      pendingRef.current.clear();
       try {
         const response = await fetch('/api/v1/x-plan/purchase-orders', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ updates: payload }),
-        })
-        if (!response.ok) throw new Error('Failed to update purchase orders')
-        toast.success('PO inputs saved')
+        });
+        if (!response.ok) throw new Error('Failed to update purchase orders');
+        toast.success('PO inputs saved');
       } catch (error) {
-        console.error(error)
-        toast.error('Unable to save purchase order inputs')
+        console.error(error);
+        toast.error('Unable to save purchase order inputs');
       }
-    }, 500)
-  }
+    }, 500);
+  };
 
   return (
-    <section className="space-y-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-        Lead & Schedule Inputs
-      </h2>
-      <HotTable
-        ref={(instance) => {
-          hotRef.current = instance?.hotInstance ?? null
-        }}
-        data={data}
-        licenseKey="non-commercial-and-evaluation"
-        columns={COLUMN_SETTINGS}
-        colHeaders={COLUMN_HEADERS}
-        stretchH="all"
-        className="x-plan-hot"
-        rowHeaders={false}
-        height="auto"
-        dropdownMenu
-        filters
-        cells={(row) => {
-          const meta = {} as Handsontable.CellMeta
-          const record = data[row]
-          if (record && activeOrderId && record.id === activeOrderId) {
-            meta.className = meta.className ? `${meta.className} row-active` : 'row-active'
-          }
-          return meta
-        }}
-        afterSelectionEnd={(row) => {
-          if (!onSelectOrder) return
-          const record = data[row]
-          if (record) onSelectOrder(record.id)
-        }}
-        afterChange={(changes, rawSource) => {
-          if (!changes || rawSource === 'loadData') return
-          const hot = hotRef.current
-          if (!hot) return
+    <GridSurface>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-2">
+          <p className="text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-slate-400">
+            Step 2
+          </p>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-50">
+            Lead &amp; Schedule Inputs
+          </h2>
+          <p className="max-w-3xl text-sm text-slate-500 dark:text-slate-400">
+            Maintain a single source of truth for purchase orders, lead time assumptions, and
+            production status. Update the blue driver cells—derived dates and inventory math will
+            ripple through the rest of the workbook.
+          </p>
+          <div className="flex flex-wrap items-center gap-2 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+            <span className="inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white/80 px-3 py-1 text-slate-600 shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200">
+              {metrics.orderCount} purchase orders
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white/80 px-3 py-1 text-slate-600 shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200">
+              {metrics.formattedUnits} units in flight
+            </span>
+          </div>
+        </div>
+        <div className="max-w-sm rounded-2xl border border-slate-200/70 bg-white/70 p-4 text-xs text-slate-600 shadow-sm dark:border-white/10 dark:bg-slate-950/50 dark:text-slate-300">
+          <p className="font-semibold text-slate-700 dark:text-slate-100">Active row</p>
+          <p className="mt-1 text-[0.65rem] uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+            {activeOrderLabel}
+          </p>
+          <p className="mt-2 leading-5">
+            Click a row or use arrow keys to focus it—linked cost overrides, payment schedules, and
+            the timeline will follow the highlighted purchase order.
+          </p>
+        </div>
+      </div>
 
-          for (const change of changes) {
-            const [rowIndex, prop, _oldValue, newValue] = change as [number, keyof OpsInputRow, any, any]
-            const record = hot.getSourceDataAtRow(rowIndex) as OpsInputRow | null
-            if (!record) continue
+      <GridLegend />
 
-            if (!pendingRef.current.has(record.id)) {
-              pendingRef.current.set(record.id, { id: record.id, values: {} })
+      <div className="x-plan-grid-shell">
+        <HotTable
+          ref={(instance) => {
+            hotRef.current = instance?.hotInstance ?? null;
+          }}
+          data={data}
+          licenseKey="non-commercial-and-evaluation"
+          columns={COLUMN_SETTINGS}
+          colHeaders={COLUMN_HEADERS}
+          stretchH="all"
+          className="x-plan-hot"
+          rowHeaders={false}
+          height="auto"
+          dropdownMenu
+          filters
+          cells={(row) => {
+            const meta = {} as Handsontable.CellMeta;
+            const record = data[row];
+            if (record && activeOrderId && record.id === activeOrderId) {
+              meta.className = meta.className ? `${meta.className} row-active` : 'row-active';
             }
-            const entry = pendingRef.current.get(record.id)
-            if (!entry) continue
+            return meta;
+          }}
+          afterSelectionEnd={(row) => {
+            if (!onSelectOrder) return;
+            const record = data[row];
+            if (record) onSelectOrder(record.id);
+          }}
+          afterChange={(changes, rawSource) => {
+            if (!changes || rawSource === 'loadData') return;
+            const hot = hotRef.current;
+            if (!hot) return;
 
-            if (NUMERIC_FIELDS.has(prop)) {
-              const precision = NUMERIC_PRECISION[prop] ?? 2
-              const normalized = normalizeNumeric(newValue, precision)
-              entry.values[prop] = normalized
-              record[prop] = normalized as OpsInputRow[typeof prop]
-            } else if (DATE_FIELDS.has(prop)) {
-              const value = newValue ? String(newValue) : ''
-              entry.values[prop] = value
-              record[prop] = value as OpsInputRow[typeof prop]
-            } else {
-              const value = newValue == null ? '' : String(newValue)
-              entry.values[prop] = value
-              record[prop] = value as OpsInputRow[typeof prop]
+            for (const change of changes) {
+              const [rowIndex, prop, _oldValue, newValue] = change as [
+                number,
+                keyof OpsInputRow,
+                any,
+                any,
+              ];
+              const record = hot.getSourceDataAtRow(rowIndex) as OpsInputRow | null;
+              if (!record) continue;
+
+              if (!pendingRef.current.has(record.id)) {
+                pendingRef.current.set(record.id, { id: record.id, values: {} });
+              }
+              const entry = pendingRef.current.get(record.id);
+              if (!entry) continue;
+
+              if (NUMERIC_FIELDS.has(prop)) {
+                const precision = NUMERIC_PRECISION[prop] ?? 2;
+                const normalized = normalizeNumeric(newValue, precision);
+                entry.values[prop] = normalized;
+                record[prop] = normalized as OpsInputRow[typeof prop];
+              } else if (DATE_FIELDS.has(prop)) {
+                const value = newValue ? String(newValue) : '';
+                entry.values[prop] = value;
+                record[prop] = value as OpsInputRow[typeof prop];
+              } else {
+                const value = newValue == null ? '' : String(newValue);
+                entry.values[prop] = value;
+                record[prop] = value as OpsInputRow[typeof prop];
+              }
             }
-          }
 
-          if (onRowsChange) {
-            const updated = (hot.getSourceData() as OpsInputRow[]).map((row) => ({ ...row }))
-            onRowsChange(updated)
-          }
+            if (onRowsChange) {
+              const updated = (hot.getSourceData() as OpsInputRow[]).map((row) => ({ ...row }));
+              onRowsChange(updated);
+            }
 
-          flush()
-        }}
-      />
-    </section>
-  )
+            flush();
+          }}
+        />
+      </div>
+    </GridSurface>
+  );
 }

--- a/apps/x-plan/components/sheets/product-setup-grid.tsx
+++ b/apps/x-plan/components/sheets/product-setup-grid.tsx
@@ -1,39 +1,40 @@
-'use client'
+'use client';
 
-import { useEffect, useMemo, useRef } from 'react'
-import { HotTable } from '@handsontable/react'
-import Handsontable from 'handsontable'
-import { registerAllModules } from 'handsontable/registry'
-import 'handsontable/dist/handsontable.full.min.css'
-import '@/styles/handsontable-theme.css'
-import { toast } from 'sonner'
-import { GridLegend } from '@/components/grid-legend'
+import { useEffect, useMemo, useRef } from 'react';
+import { HotTable } from '@handsontable/react';
+import Handsontable from 'handsontable';
+import { registerAllModules } from 'handsontable/registry';
+import 'handsontable/dist/handsontable.full.min.css';
+import '@/styles/handsontable-theme.css';
+import { toast } from 'sonner';
+import { GridLegend } from '@/components/grid-legend';
+import { GridSurface } from '@/components/grid-surface';
 
-registerAllModules()
+registerAllModules();
 
 type ProductRow = {
-  id: string
-  name: string
-  sellingPrice: string
-  manufacturingCost: string
-  freightCost: string
-  tariffRate: string
-  tacosPercent: string
-  fbaFee: string
-  amazonReferralRate: string
-  storagePerMonth: string
-  landedCost: string
-  grossContribution: string
-  grossMarginPercent: string
-}
+  id: string;
+  name: string;
+  sellingPrice: string;
+  manufacturingCost: string;
+  freightCost: string;
+  tariffRate: string;
+  tacosPercent: string;
+  fbaFee: string;
+  amazonReferralRate: string;
+  storagePerMonth: string;
+  landedCost: string;
+  grossContribution: string;
+  grossMarginPercent: string;
+};
 
 type ProductUpdate = {
-  id: string
-  values: Partial<Record<keyof ProductRow, string>>
-}
+  id: string;
+  values: Partial<Record<keyof ProductRow, string>>;
+};
 
 interface ProductSetupGridProps {
-  products: Array<ProductRow>
+  products: Array<ProductRow>;
 }
 
 const COLUMN_HEADERS = [
@@ -49,22 +50,80 @@ const COLUMN_HEADERS = [
   'Landed Cost',
   'Gross Contribution',
   'Gross Margin %',
-]
+];
 
 const COLUMN_CONFIG: Handsontable.ColumnSettings[] = [
   { data: 'name', readOnly: true, className: 'cell-readonly' },
-  { data: 'sellingPrice', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, className: 'cell-editable' },
-  { data: 'manufacturingCost', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, className: 'cell-editable' },
-  { data: 'freightCost', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, className: 'cell-editable' },
-  { data: 'tariffRate', type: 'numeric', numericFormat: { pattern: '0.00%' }, className: 'cell-editable' },
-  { data: 'tacosPercent', type: 'numeric', numericFormat: { pattern: '0.00%' }, className: 'cell-editable' },
-  { data: 'fbaFee', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, className: 'cell-editable' },
-  { data: 'amazonReferralRate', type: 'numeric', numericFormat: { pattern: '0.00%' }, className: 'cell-editable' },
-  { data: 'storagePerMonth', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, className: 'cell-editable' },
-  { data: 'landedCost', readOnly: true, className: 'cell-readonly', type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
-  { data: 'grossContribution', readOnly: true, className: 'cell-readonly', type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
-  { data: 'grossMarginPercent', readOnly: true, className: 'cell-readonly', type: 'numeric', numericFormat: { pattern: '0.00%' } },
-]
+  {
+    data: 'sellingPrice',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0.00' },
+    className: 'cell-editable',
+  },
+  {
+    data: 'manufacturingCost',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0.00' },
+    className: 'cell-editable',
+  },
+  {
+    data: 'freightCost',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0.00' },
+    className: 'cell-editable',
+  },
+  {
+    data: 'tariffRate',
+    type: 'numeric',
+    numericFormat: { pattern: '0.00%' },
+    className: 'cell-editable',
+  },
+  {
+    data: 'tacosPercent',
+    type: 'numeric',
+    numericFormat: { pattern: '0.00%' },
+    className: 'cell-editable',
+  },
+  {
+    data: 'fbaFee',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0.00' },
+    className: 'cell-editable',
+  },
+  {
+    data: 'amazonReferralRate',
+    type: 'numeric',
+    numericFormat: { pattern: '0.00%' },
+    className: 'cell-editable',
+  },
+  {
+    data: 'storagePerMonth',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0.00' },
+    className: 'cell-editable',
+  },
+  {
+    data: 'landedCost',
+    readOnly: true,
+    className: 'cell-readonly',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0.00' },
+  },
+  {
+    data: 'grossContribution',
+    readOnly: true,
+    className: 'cell-readonly',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0.00' },
+  },
+  {
+    data: 'grossMarginPercent',
+    readOnly: true,
+    className: 'cell-readonly',
+    type: 'numeric',
+    numericFormat: { pattern: '0.00%' },
+  },
+];
 
 const NUMERIC_FIELDS: Array<keyof ProductRow> = [
   'sellingPrice',
@@ -75,127 +134,212 @@ const NUMERIC_FIELDS: Array<keyof ProductRow> = [
   'fbaFee',
   'amazonReferralRate',
   'storagePerMonth',
-]
+];
 
-const DERIVED_FIELDS: Array<keyof ProductRow> = ['landedCost', 'grossContribution', 'grossMarginPercent']
+const DERIVED_FIELDS: Array<keyof ProductRow> = [
+  'landedCost',
+  'grossContribution',
+  'grossMarginPercent',
+];
 
 function normalizeNumeric(value: unknown) {
-  if (value === '' || value === null || value === undefined) return ''
-  const numeric = Number(value)
-  if (Number.isNaN(numeric)) return String(value ?? '')
-  return numeric.toFixed(2)
+  if (value === '' || value === null || value === undefined) return '';
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) return String(value ?? '');
+  return numeric.toFixed(2);
 }
 
 function parseNumeric(value: string) {
-  const numeric = Number(value)
-  return Number.isNaN(numeric) ? 0 : numeric
+  const numeric = Number(value);
+  return Number.isNaN(numeric) ? 0 : numeric;
 }
 
 function recalculateDerived(row: ProductRow) {
-  const price = parseNumeric(row.sellingPrice)
-  const manufacturing = parseNumeric(row.manufacturingCost)
-  const freight = parseNumeric(row.freightCost)
-  const tariffRate = parseNumeric(row.tariffRate)
-  const tacosRate = parseNumeric(row.tacosPercent)
-  const fba = parseNumeric(row.fbaFee)
-  const storage = parseNumeric(row.storagePerMonth)
+  const price = parseNumeric(row.sellingPrice);
+  const manufacturing = parseNumeric(row.manufacturingCost);
+  const freight = parseNumeric(row.freightCost);
+  const tariffRate = parseNumeric(row.tariffRate);
+  const tacosRate = parseNumeric(row.tacosPercent);
+  const fba = parseNumeric(row.fbaFee);
+  const storage = parseNumeric(row.storagePerMonth);
 
-  const tariffCost = price * tariffRate
-  const advertising = price * tacosRate
-  const landedCost = manufacturing + freight + tariffCost + fba + storage
-  const grossContribution = price - landedCost - advertising
-  const marginPercent = price === 0 ? 0 : grossContribution / price
+  const tariffCost = price * tariffRate;
+  const advertising = price * tacosRate;
+  const landedCost = manufacturing + freight + tariffCost + fba + storage;
+  const grossContribution = price - landedCost - advertising;
+  const marginPercent = price === 0 ? 0 : grossContribution / price;
 
-  row.landedCost = landedCost.toFixed(2)
-  row.grossContribution = grossContribution.toFixed(2)
-  row.grossMarginPercent = marginPercent.toFixed(4)
+  row.landedCost = landedCost.toFixed(2);
+  row.grossContribution = grossContribution.toFixed(2);
+  row.grossMarginPercent = marginPercent.toFixed(4);
 }
 
 export function ProductSetupGrid({ products }: ProductSetupGridProps) {
-  const hotRef = useRef<Handsontable | null>(null)
-  const pendingUpdatesRef = useRef<Map<string, ProductUpdate>>(new Map())
-  const flushTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const hotRef = useRef<Handsontable | null>(null);
+  const pendingUpdatesRef = useRef<Map<string, ProductUpdate>>(new Map());
+  const flushTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const data = useMemo<ProductRow[]>(() => products.map((product) => ({ ...product })), [products])
+  const data = useMemo<ProductRow[]>(() => products.map((product) => ({ ...product })), [products]);
+
+  const summary = useMemo(() => {
+    if (data.length === 0) {
+      return { averageMargin: '0.0', averageContribution: '0.00' };
+    }
+    let marginTotal = 0;
+    let contributionTotal = 0;
+    for (const row of data) {
+      marginTotal += Number(row.grossMarginPercent ?? 0);
+      contributionTotal += Number(row.grossContribution ?? 0);
+    }
+    const averageMargin = Number.isFinite(marginTotal)
+      ? ((marginTotal / data.length) * 100).toFixed(1)
+      : '0.0';
+    const averageContribution = Number.isFinite(contributionTotal)
+      ? (contributionTotal / data.length).toFixed(2)
+      : '0.00';
+    return { averageMargin, averageContribution };
+  }, [data]);
 
   useEffect(() => {
     if (hotRef.current) {
-      hotRef.current.loadData(data)
+      hotRef.current.loadData(data);
     }
-  }, [data])
+  }, [data]);
 
   const queueFlush = () => {
-    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current)
+    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current);
     flushTimeoutRef.current = setTimeout(async () => {
-      const payload = Array.from(pendingUpdatesRef.current.values())
-      if (payload.length === 0) return
-      pendingUpdatesRef.current.clear()
+      const payload = Array.from(pendingUpdatesRef.current.values());
+      if (payload.length === 0) return;
+      pendingUpdatesRef.current.clear();
       try {
         const res = await fetch('/api/v1/x-plan/products', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ updates: payload }),
-        })
-        if (!res.ok) throw new Error('Failed to save updates')
-        toast.success('Product setup updated')
+        });
+        if (!res.ok) throw new Error('Failed to save updates');
+        toast.success('Product setup updated');
       } catch (error) {
-        console.error(error)
-        toast.error('Unable to save product updates')
+        console.error(error);
+        toast.error('Unable to save product updates');
       }
-    }, 500)
-  }
+    }, 500);
+  };
 
   return (
-    <div className="space-y-4 p-4">
-      <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Product Pricing & Costs</h2>
-      <HotTable
-        ref={(instance) => {
-          hotRef.current = instance?.hotInstance ?? null
-        }}
-        data={data}
-        licenseKey="non-commercial-and-evaluation"
-        colHeaders={COLUMN_HEADERS}
-        columns={COLUMN_CONFIG}
-        rowHeaders={false}
-        height="auto"
-        stretchH="all"
-        className="x-plan-hot"
-        dropdownMenu
-        filters
-        afterGetColHeader={(col, TH) => {
-          if (col === 0) TH.classList.add('htLeft')
-        }}
-        afterChange={(changes, source) => {
-          const changeSource = String(source)
-          if (!changes || changeSource === 'loadData' || changeSource === 'derived-update') return
-          const hot = hotRef.current
-          if (!hot) return
-          const rowsRef = hot.getSourceData() as ProductRow[]
-          for (const change of changes) {
-            const [rowIndex, prop, _oldValue, newValue] = change as [number, keyof ProductRow, any, any]
-            if (newValue === undefined) continue
-            const record = rowsRef[rowIndex]
-            if (!record) continue
-            if (DERIVED_FIELDS.includes(prop)) continue
-            if (!pendingUpdatesRef.current.has(record.id)) {
-              pendingUpdatesRef.current.set(record.id, { id: record.id, values: {} })
+    <GridSurface>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Step 1
+            </p>
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-50">
+              Product Pricing &amp; Costs
+            </h2>
+            <p className="max-w-2xl text-sm text-slate-500 dark:text-slate-400">
+              Tune selling price, landed cost, and ad spend assumptions. Margin outputs refresh
+              instantly so you can sense check viability as you type.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+            <span className="inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white/80 px-3 py-1 text-slate-600 shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200">
+              <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+              {data.length} active SKUs
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-slate-300/60 bg-white/70 px-3 py-1 text-slate-600 shadow-sm dark:border-white/10 dark:bg-slate-900/50 dark:text-slate-200">
+              Avg margin {summary.averageMargin}%
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-slate-300/60 bg-white/70 px-3 py-1 text-slate-600 shadow-sm dark:border-white/10 dark:bg-slate-900/50 dark:text-slate-200">
+              Avg gross ${summary.averageContribution}
+            </span>
+          </div>
+        </div>
+        <div className="max-w-sm rounded-2xl border border-slate-200/70 bg-white/70 p-4 text-xs leading-5 text-slate-600 shadow-sm dark:border-white/10 dark:bg-slate-950/50 dark:text-slate-300">
+          <p className="font-semibold text-slate-700 dark:text-slate-100">Auto-sync safety net</p>
+          <p className="mt-2">
+            Updates queue while you edit and save a moment after you pause. If anything fails,
+            you&apos;ll see a toast with what to retry.
+          </p>
+        </div>
+      </div>
+
+      <GridLegend />
+
+      <div className="x-plan-grid-shell">
+        <HotTable
+          ref={(instance) => {
+            hotRef.current = instance?.hotInstance ?? null;
+          }}
+          data={data}
+          licenseKey="non-commercial-and-evaluation"
+          colHeaders={COLUMN_HEADERS}
+          columns={COLUMN_CONFIG}
+          rowHeaders={false}
+          height="auto"
+          stretchH="all"
+          className="x-plan-hot"
+          dropdownMenu
+          filters
+          afterGetColHeader={(col, TH) => {
+            if (col === 0) TH.classList.add('htLeft');
+          }}
+          afterChange={(changes, source) => {
+            const changeSource = String(source);
+            if (!changes || changeSource === 'loadData' || changeSource === 'derived-update')
+              return;
+            const hot = hotRef.current;
+            if (!hot) return;
+            const rowsRef = hot.getSourceData() as ProductRow[];
+            for (const change of changes) {
+              const [rowIndex, prop, _oldValue, newValue] = change as [
+                number,
+                keyof ProductRow,
+                any,
+                any,
+              ];
+              if (newValue === undefined) continue;
+              const record = rowsRef[rowIndex];
+              if (!record) continue;
+              if (DERIVED_FIELDS.includes(prop)) continue;
+              if (!pendingUpdatesRef.current.has(record.id)) {
+                pendingUpdatesRef.current.set(record.id, { id: record.id, values: {} });
+              }
+              const entry = pendingUpdatesRef.current.get(record.id);
+              if (!entry) continue;
+              entry.values[prop] = NUMERIC_FIELDS.includes(prop)
+                ? normalizeNumeric(newValue)
+                : String(newValue ?? '');
+              const updatedRow = {
+                ...record,
+                [prop]: entry.values[prop],
+              };
+              recalculateDerived(updatedRow);
+              hot.setDataAtRowProp(rowIndex, 'landedCost', updatedRow.landedCost, 'derived-update');
+              hot.setDataAtRowProp(
+                rowIndex,
+                'grossContribution',
+                updatedRow.grossContribution,
+                'derived-update',
+              );
+              hot.setDataAtRowProp(
+                rowIndex,
+                'grossMarginPercent',
+                updatedRow.grossMarginPercent,
+                'derived-update',
+              );
+              Object.assign(record, updatedRow);
             }
-            const entry = pendingUpdatesRef.current.get(record.id)
-            if (!entry) continue
-            entry.values[prop] = NUMERIC_FIELDS.includes(prop) ? normalizeNumeric(newValue) : String(newValue ?? '')
-            const updatedRow = {
-              ...record,
-              [prop]: entry.values[prop],
-            }
-            recalculateDerived(updatedRow)
-            hot.setDataAtRowProp(rowIndex, 'landedCost', updatedRow.landedCost, 'derived-update')
-            hot.setDataAtRowProp(rowIndex, 'grossContribution', updatedRow.grossContribution, 'derived-update')
-            hot.setDataAtRowProp(rowIndex, 'grossMarginPercent', updatedRow.grossMarginPercent, 'derived-update')
-            Object.assign(record, updatedRow)
-          }
-          queueFlush()
-        }}
-      />
-    </div>
-  )
+            queueFlush();
+          }}
+        />
+      </div>
+
+      <p className="text-xs text-slate-500 dark:text-slate-400">
+        Need a quick export? Jump to Import / Export in the header—your latest tweaks will already
+        be synced.
+      </p>
+    </GridSurface>
+  );
 }

--- a/apps/x-plan/components/sheets/purchase-payments-grid.tsx
+++ b/apps/x-plan/components/sheets/purchase-payments-grid.tsx
@@ -1,253 +1,333 @@
-'use client'
+'use client';
 
-import { useEffect, useMemo, useRef } from 'react'
-import { HotTable } from '@handsontable/react'
-import Handsontable from 'handsontable'
-import { registerAllModules } from 'handsontable/registry'
-import 'handsontable/dist/handsontable.full.min.css'
-import '@/styles/handsontable-theme.css'
-import { toast } from 'sonner'
-import { GridLegend } from '@/components/grid-legend'
+import { useEffect, useMemo, useRef } from 'react';
+import { HotTable } from '@handsontable/react';
+import Handsontable from 'handsontable';
+import { registerAllModules } from 'handsontable/registry';
+import 'handsontable/dist/handsontable.full.min.css';
+import '@/styles/handsontable-theme.css';
+import { toast } from 'sonner';
+import { GridLegend } from '@/components/grid-legend';
+import { GridSurface } from '@/components/grid-surface';
 
-registerAllModules()
+registerAllModules();
 
 export type PurchasePaymentRow = {
-  id: string
-  purchaseOrderId: string
-  orderCode: string
-  paymentIndex: number
-  dueDate: string
-  percentage: string
-  amount: string
-  status: string
-}
+  id: string;
+  purchaseOrderId: string;
+  orderCode: string;
+  paymentIndex: number;
+  dueDate: string;
+  percentage: string;
+  amount: string;
+  status: string;
+};
 
 type PaymentUpdate = {
-  id: string
-  values: Partial<Record<keyof PurchasePaymentRow, string>>
-}
+  id: string;
+  values: Partial<Record<keyof PurchasePaymentRow, string>>;
+};
 
 export interface PaymentSummary {
-  plannedAmount: number
-  plannedPercent: number
-  actualAmount: number
-  actualPercent: number
-  remainingAmount: number
-  remainingPercent: number
+  plannedAmount: number;
+  plannedPercent: number;
+  actualAmount: number;
+  actualPercent: number;
+  remainingAmount: number;
+  remainingPercent: number;
 }
 
 interface PurchasePaymentsGridProps {
-  payments: PurchasePaymentRow[]
-  activeOrderId?: string | null
-  onSelectOrder?: (orderId: string) => void
-  onAddPayment?: () => void
-  onRowsChange?: (rows: PurchasePaymentRow[]) => void
-  isLoading?: boolean
-  orderSummaries?: Map<string, PaymentSummary>
-  summaryLine?: string | null
+  payments: PurchasePaymentRow[];
+  activeOrderId?: string | null;
+  onSelectOrder?: (orderId: string) => void;
+  onAddPayment?: () => void;
+  onRowsChange?: (rows: PurchasePaymentRow[]) => void;
+  isLoading?: boolean;
+  orderSummaries?: Map<string, PaymentSummary>;
+  summaryLine?: string | null;
 }
 
-const HEADERS = ['PO', '#', 'Due Date', 'Percent', 'Amount', 'Status']
+const HEADERS = ['PO', '#', 'Due Date', 'Percent', 'Amount', 'Status'];
 
 const COLUMNS: Handsontable.ColumnSettings[] = [
   { data: 'orderCode', readOnly: true, className: 'cell-readonly' },
   { data: 'paymentIndex', readOnly: true, className: 'cell-readonly' },
-  { data: 'dueDate', type: 'date', dateFormat: 'MMM D YYYY', correctFormat: true, className: 'cell-editable' },
-  { data: 'percentage', type: 'numeric', numericFormat: { pattern: '0.00%' }, readOnly: true, className: 'cell-readonly' },
-  { data: 'amount', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, className: 'cell-editable' },
+  {
+    data: 'dueDate',
+    type: 'date',
+    dateFormat: 'MMM D YYYY',
+    correctFormat: true,
+    className: 'cell-editable',
+  },
+  {
+    data: 'percentage',
+    type: 'numeric',
+    numericFormat: { pattern: '0.00%' },
+    readOnly: true,
+    className: 'cell-readonly',
+  },
+  {
+    data: 'amount',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0.00' },
+    className: 'cell-editable',
+  },
   {
     data: 'status',
     type: 'dropdown',
     source: ['pending', 'scheduled', 'paid', 'cancelled'],
     className: 'cell-editable',
   },
-]
+];
 
-const NUMERIC_FIELDS: Array<keyof PurchasePaymentRow> = ['amount']
+const NUMERIC_FIELDS: Array<keyof PurchasePaymentRow> = ['amount'];
 
 function normalizeNumeric(value: unknown) {
-  if (value === '' || value === null || value === undefined) return ''
-  const numeric = Number(value)
-  if (Number.isNaN(numeric)) return String(value ?? '')
-  return numeric.toFixed(2)
+  if (value === '' || value === null || value === undefined) return '';
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) return String(value ?? '');
+  return numeric.toFixed(2);
 }
 
 function normalizePercent(value: unknown) {
-  if (value === '' || value === null || value === undefined) return ''
-  const numeric = Number(value)
-  if (Number.isNaN(numeric)) return String(value ?? '')
-  const base = numeric > 1 ? numeric / 100 : numeric
-  return base.toFixed(4)
+  if (value === '' || value === null || value === undefined) return '';
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) return String(value ?? '');
+  const base = numeric > 1 ? numeric / 100 : numeric;
+  return base.toFixed(4);
 }
 
-export function PurchasePaymentsGrid({ payments, activeOrderId, onSelectOrder, onAddPayment, onRowsChange, isLoading, orderSummaries, summaryLine }: PurchasePaymentsGridProps) {
-  const hotRef = useRef<Handsontable | null>(null)
-  const pendingRef = useRef<Map<string, PaymentUpdate>>(new Map())
-  const flushTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+export function PurchasePaymentsGrid({
+  payments,
+  activeOrderId,
+  onSelectOrder,
+  onAddPayment,
+  onRowsChange,
+  isLoading,
+  orderSummaries,
+  summaryLine,
+}: PurchasePaymentsGridProps) {
+  const hotRef = useRef<Handsontable | null>(null);
+  const pendingRef = useRef<Map<string, PaymentUpdate>>(new Map());
+  const flushTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const data = useMemo(() => {
-    const scoped = activeOrderId ? payments.filter((payment) => payment.purchaseOrderId === activeOrderId) : payments
-    return scoped.map((payment) => ({ ...payment }))
-  }, [activeOrderId, payments])
+    const scoped = activeOrderId
+      ? payments.filter((payment) => payment.purchaseOrderId === activeOrderId)
+      : payments;
+    return scoped.map((payment) => ({ ...payment }));
+  }, [activeOrderId, payments]);
 
-  const summary = activeOrderId ? orderSummaries?.get(activeOrderId) : undefined
+  const summary = activeOrderId ? orderSummaries?.get(activeOrderId) : undefined;
+
+  const activeOrderLabel = useMemo(() => {
+    if (!activeOrderId) return null;
+    const match = payments.find((payment) => payment.purchaseOrderId === activeOrderId);
+    if (!match) return null;
+    return match.orderCode;
+  }, [activeOrderId, payments]);
 
   const isFullyAllocated = useMemo(() => {
-    if (!summary) return false
-    const amountTolerance = Math.max(summary.plannedAmount * 0.001, 0.01)
-    const percentTolerance = Math.max(summary.plannedPercent * 0.001, 0.001)
-    const amountCleared = summary.plannedAmount > 0 && summary.remainingAmount <= amountTolerance
-    const percentCleared = summary.plannedPercent > 0 && summary.remainingPercent <= percentTolerance
-    return amountCleared || percentCleared
-  }, [summary])
+    if (!summary) return false;
+    const amountTolerance = Math.max(summary.plannedAmount * 0.001, 0.01);
+    const percentTolerance = Math.max(summary.plannedPercent * 0.001, 0.001);
+    const amountCleared = summary.plannedAmount > 0 && summary.remainingAmount <= amountTolerance;
+    const percentCleared =
+      summary.plannedPercent > 0 && summary.remainingPercent <= percentTolerance;
+    return amountCleared || percentCleared;
+  }, [summary]);
 
   const computedSummaryLine = useMemo(() => {
-    if (!summary) return null
-    const parts: string[] = []
-    parts.push(`Plan ${summary.plannedAmount.toFixed(2)}`)
+    if (!summary) return null;
+    const parts: string[] = [];
+    parts.push(`Plan ${summary.plannedAmount.toFixed(2)}`);
     if (summary.plannedAmount > 0) {
-      const paidPercent = Math.max(summary.actualPercent * 100, 0).toFixed(1)
-      parts.push(`Paid ${summary.actualAmount.toFixed(2)} (${paidPercent}%)`)
+      const paidPercent = Math.max(summary.actualPercent * 100, 0).toFixed(1);
+      parts.push(`Paid ${summary.actualAmount.toFixed(2)} (${paidPercent}%)`);
       if (summary.remainingAmount > 0.01) {
-        parts.push(`Remaining ${summary.remainingAmount.toFixed(2)}`)
+        parts.push(`Remaining ${summary.remainingAmount.toFixed(2)}`);
       } else if (summary.remainingAmount < -0.01) {
-        parts.push(`Cleared (+$${Math.abs(summary.remainingAmount).toFixed(2)})`)
+        parts.push(`Cleared (+$${Math.abs(summary.remainingAmount).toFixed(2)})`);
       } else {
-        parts.push('Cleared')
+        parts.push('Cleared');
       }
     } else {
-      parts.push(`Paid ${summary.actualAmount.toFixed(2)}`)
+      parts.push(`Paid ${summary.actualAmount.toFixed(2)}`);
     }
-    return parts.join(' • ')
-  }, [summary])
+    return parts.join(' • ');
+  }, [summary]);
 
-  const summaryText = summaryLine ?? computedSummaryLine
+  const summaryText = summaryLine ?? computedSummaryLine;
 
   useEffect(() => {
     if (hotRef.current) {
-      hotRef.current.loadData(data)
+      hotRef.current.loadData(data);
     }
-  }, [data])
+  }, [data]);
 
   const flush = () => {
-    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current)
+    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current);
     flushTimeoutRef.current = setTimeout(async () => {
-      const payload = Array.from(pendingRef.current.values())
-      if (payload.length === 0) return
-      pendingRef.current.clear()
+      const payload = Array.from(pendingRef.current.values());
+      if (payload.length === 0) return;
+      pendingRef.current.clear();
       try {
         const res = await fetch('/api/v1/x-plan/purchase-order-payments', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ updates: payload }),
-        })
-        if (!res.ok) throw new Error('Failed to update payments')
+        });
+        if (!res.ok) throw new Error('Failed to update payments');
         if (onRowsChange && hotRef.current) {
-          const updated = (hotRef.current.getSourceData() as PurchasePaymentRow[]).map((row) => ({ ...row }))
-          onRowsChange(updated)
+          const updated = (hotRef.current.getSourceData() as PurchasePaymentRow[]).map((row) => ({
+            ...row,
+          }));
+          onRowsChange(updated);
         }
-        toast.success('Payment schedule updated')
+        toast.success('Payment schedule updated');
       } catch (error) {
-        console.error(error)
-        toast.error('Unable to update payment schedule')
+        console.error(error);
+        toast.error('Unable to update payment schedule');
       }
-    }, 400)
-  }
+    }, 400);
+  };
 
   return (
-    <div className="space-y-3 p-4">
-      <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Supplier Payments</h2>
-        <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
-          {summaryText && <span>{summaryText}</span>}
+    <GridSurface>
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-2">
+          <p className="text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-slate-400">
+            Supplier payments
+          </p>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-50">
+            Cash Timing Tracker
+          </h2>
+          <p className="max-w-3xl text-sm text-slate-500 dark:text-slate-400">
+            Keep payout schedules in lock-step with each purchase order. Amounts stay balanced
+            against the PO total, and percent splits auto-adjust as you edit.
+          </p>
+          {summaryText && (
+            <p className="inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white/80 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-slate-500 shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-300">
+              {summaryText}
+            </p>
+          )}
+          {activeOrderLabel && (
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Active PO: {activeOrderLabel}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-col items-start gap-3">
           <button
             onClick={onAddPayment}
             disabled={!activeOrderId || isLoading || isFullyAllocated}
-            className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 transition enabled:hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:enabled:hover:bg-slate-800"
+            className="inline-flex items-center justify-center rounded-xl bg-gradient-to-r from-purple-500 to-pink-500 px-4 py-2 text-xs font-semibold text-white shadow-lg transition focus:outline-none focus:ring-2 focus:ring-purple-400/60 enabled:hover:from-purple-500/90 enabled:hover:to-pink-500/90 disabled:cursor-not-allowed disabled:opacity-60"
           >
             Add Payment
           </button>
+          <p className="max-w-xs text-[0.65rem] leading-5 text-slate-500 dark:text-slate-400">
+            Need another milestone? Add it here—percentages will re-balance automatically. Payments
+            that clear the total are marked as fully allocated.
+          </p>
         </div>
       </div>
-      <HotTable
-        ref={(instance) => {
-          hotRef.current = instance?.hotInstance ?? null
-        }}
-        data={data}
-        licenseKey="non-commercial-and-evaluation"
-        colHeaders={HEADERS}
-        columns={COLUMNS}
-        rowHeaders={false}
-        height="auto"
-        stretchH="all"
-        className="x-plan-hot"
-        dropdownMenu
-        filters
-        cells={(row) => {
-          const meta = {} as Handsontable.CellMeta
-          const record = data[row]
-          if (record && activeOrderId && record.purchaseOrderId === activeOrderId) {
-            meta.className = meta.className ? `${meta.className} row-active` : 'row-active'
-          }
-          return meta
-        }}
-        afterSelectionEnd={(row) => {
-          if (!onSelectOrder) return
-          const record = data[row]
-          if (record) onSelectOrder(record.purchaseOrderId)
-        }}
-        afterChange={(changes, rawSource) => {
-          const source = String(rawSource)
-          if (!changes || source === 'loadData' || source === 'derived-update') return
-          const hot = hotRef.current
-          if (!hot) return
-          for (const change of changes) {
-            const [rowIndex, prop, _oldValue, newValue] = change as [number, keyof PurchasePaymentRow, any, any]
-            const record = hot.getSourceDataAtRow(rowIndex) as PurchasePaymentRow | null
-            if (!record) continue
-            if (!pendingRef.current.has(record.id)) {
-              pendingRef.current.set(record.id, { id: record.id, values: {} })
+
+      <GridLegend />
+
+      <div className="x-plan-grid-shell">
+        <HotTable
+          ref={(instance) => {
+            hotRef.current = instance?.hotInstance ?? null;
+          }}
+          data={data}
+          licenseKey="non-commercial-and-evaluation"
+          colHeaders={HEADERS}
+          columns={COLUMNS}
+          rowHeaders={false}
+          height="auto"
+          stretchH="all"
+          className="x-plan-hot"
+          dropdownMenu
+          filters
+          cells={(row) => {
+            const meta = {} as Handsontable.CellMeta;
+            const record = data[row];
+            if (record && activeOrderId && record.purchaseOrderId === activeOrderId) {
+              meta.className = meta.className ? `${meta.className} row-active` : 'row-active';
             }
-            const entry = pendingRef.current.get(record.id)
-            if (!entry) continue
-            if (prop === 'dueDate') {
-              entry.values[prop] = newValue ?? ''
-            } else if (NUMERIC_FIELDS.includes(prop)) {
-              const normalizedAmount = normalizeNumeric(newValue)
-              entry.values[prop] = normalizedAmount
-              const plannedAmount = orderSummaries?.get(record.purchaseOrderId)?.plannedAmount ?? 0
-              const numericAmount = Number(normalizedAmount ?? 0)
-              if (plannedAmount > 0 && Number.isFinite(numericAmount)) {
-                const amountTolerance = Math.max(plannedAmount * 0.001, 0.01)
-                const totalAmount = (hot.getSourceData() as PurchasePaymentRow[])
-                  .filter((row) => row.purchaseOrderId === record.purchaseOrderId)
-                  .reduce((sum, row) => sum + Number(row.amount ?? 0), 0)
-
-                if (totalAmount > plannedAmount + amountTolerance) {
-                  const previousAmountString = _oldValue == null || _oldValue === '' ? '0.00' : normalizeNumeric(_oldValue)
-                  entry.values.amount = previousAmountString
-                  const previousPercent = normalizePercent(
-                    plannedAmount > 0 ? Number(previousAmountString ?? 0) / plannedAmount : 0
-                  )
-                  entry.values.percentage = previousPercent
-                  hot.setDataAtRowProp(rowIndex, 'amount', previousAmountString, 'derived-update')
-                  hot.setDataAtRowProp(rowIndex, 'percentage', previousPercent, 'derived-update')
-                  toast.error('Payments exceed the PO total. Adjust amounts before adding more.')
-                  continue
-                }
-
-                const derivedPercent = numericAmount / plannedAmount
-                const normalizedPercent = normalizePercent(derivedPercent)
-                entry.values.percentage = normalizedPercent
-                hot.setDataAtRowProp(rowIndex, 'percentage', normalizedPercent, 'derived-update')
+            return meta;
+          }}
+          afterSelectionEnd={(row) => {
+            if (!onSelectOrder) return;
+            const record = data[row];
+            if (record) onSelectOrder(record.purchaseOrderId);
+          }}
+          afterChange={(changes, rawSource) => {
+            const source = String(rawSource);
+            if (!changes || source === 'loadData' || source === 'derived-update') return;
+            const hot = hotRef.current;
+            if (!hot) return;
+            for (const change of changes) {
+              const [rowIndex, prop, _oldValue, newValue] = change as [
+                number,
+                keyof PurchasePaymentRow,
+                any,
+                any,
+              ];
+              const record = hot.getSourceDataAtRow(rowIndex) as PurchasePaymentRow | null;
+              if (!record) continue;
+              if (!pendingRef.current.has(record.id)) {
+                pendingRef.current.set(record.id, { id: record.id, values: {} });
               }
-            } else {
-              entry.values[prop] = String(newValue ?? '')
+              const entry = pendingRef.current.get(record.id);
+              if (!entry) continue;
+              if (prop === 'dueDate') {
+                entry.values[prop] = newValue ?? '';
+              } else if (NUMERIC_FIELDS.includes(prop)) {
+                const normalizedAmount = normalizeNumeric(newValue);
+                entry.values[prop] = normalizedAmount;
+                const plannedAmount =
+                  orderSummaries?.get(record.purchaseOrderId)?.plannedAmount ?? 0;
+                const numericAmount = Number(normalizedAmount ?? 0);
+                if (plannedAmount > 0 && Number.isFinite(numericAmount)) {
+                  const amountTolerance = Math.max(plannedAmount * 0.001, 0.01);
+                  const totalAmount = (hot.getSourceData() as PurchasePaymentRow[])
+                    .filter((row) => row.purchaseOrderId === record.purchaseOrderId)
+                    .reduce((sum, row) => sum + Number(row.amount ?? 0), 0);
+
+                  if (totalAmount > plannedAmount + amountTolerance) {
+                    const previousAmountString =
+                      _oldValue == null || _oldValue === '' ? '0.00' : normalizeNumeric(_oldValue);
+                    entry.values.amount = previousAmountString;
+                    const previousPercent = normalizePercent(
+                      plannedAmount > 0 ? Number(previousAmountString ?? 0) / plannedAmount : 0,
+                    );
+                    entry.values.percentage = previousPercent;
+                    hot.setDataAtRowProp(
+                      rowIndex,
+                      'amount',
+                      previousAmountString,
+                      'derived-update',
+                    );
+                    hot.setDataAtRowProp(rowIndex, 'percentage', previousPercent, 'derived-update');
+                    toast.error('Payments exceed the PO total. Adjust amounts before adding more.');
+                    continue;
+                  }
+
+                  const derivedPercent = numericAmount / plannedAmount;
+                  const normalizedPercent = normalizePercent(derivedPercent);
+                  entry.values.percentage = normalizedPercent;
+                  hot.setDataAtRowProp(rowIndex, 'percentage', normalizedPercent, 'derived-update');
+                }
+              } else {
+                entry.values[prop] = String(newValue ?? '');
+              }
             }
-          }
-          flush()
-        }}
-      />
-    </div>
-  )
+            flush();
+          }}
+        />
+      </div>
+    </GridSurface>
+  );
 }

--- a/apps/x-plan/components/sheets/sales-planning-grid.tsx
+++ b/apps/x-plan/components/sheets/sales-planning-grid.tsx
@@ -1,184 +1,235 @@
-'use client'
+'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { HotTable } from '@handsontable/react'
-import Handsontable from 'handsontable'
-import { registerAllModules } from 'handsontable/registry'
-import 'handsontable/dist/handsontable.full.min.css'
-import '@/styles/handsontable-theme.css'
-import { toast } from 'sonner'
-import { GridLegend } from '@/components/grid-legend'
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react';
+import Handsontable from 'handsontable';
+import { registerAllModules } from 'handsontable/registry';
+import 'handsontable/dist/handsontable.full.min.css';
+import '@/styles/handsontable-theme.css';
+import { toast } from 'sonner';
+import { GridLegend } from '@/components/grid-legend';
+import { GridSurface } from '@/components/grid-surface';
 
-registerAllModules()
+registerAllModules();
 
 type SalesRow = {
-  weekNumber: string
-  weekDate: string
-  [key: string]: string
-}
+  weekNumber: string;
+  weekDate: string;
+  [key: string]: string;
+};
 
-type ColumnMeta = Record<string, { productId: string; field: string }>
+type ColumnMeta = Record<string, { productId: string; field: string }>;
 
-const metrics = ['stockStart', 'actualSales', 'forecastSales', 'finalSales', 'stockWeeks', 'stockEnd'] as const
-const editableMetrics = new Set(['actualSales', 'forecastSales'])
+const metrics = [
+  'stockStart',
+  'actualSales',
+  'forecastSales',
+  'finalSales',
+  'stockWeeks',
+  'stockEnd',
+] as const;
+const editableMetrics = new Set(['actualSales', 'forecastSales']);
 
 type SalesUpdate = {
-  productId: string
-  weekNumber: number
-  values: Record<string, string>
-}
+  productId: string;
+  weekNumber: number;
+  values: Record<string, string>;
+};
 
 interface SalesPlanningGridProps {
-  rows: SalesRow[]
-  columnMeta: ColumnMeta
-  nestedHeaders: (string | { label: string; colspan: number })[][]
-  columnKeys: string[]
-  productOptions: Array<{ id: string; name: string }>
+  rows: SalesRow[];
+  columnMeta: ColumnMeta;
+  nestedHeaders: (string | { label: string; colspan: number })[][];
+  columnKeys: string[];
+  productOptions: Array<{ id: string; name: string }>;
 }
 
 function normalizeEditableValue(value: unknown) {
-  if (value === '' || value === null || value === undefined) return ''
-  const numeric = Number(value)
-  if (Number.isNaN(numeric)) return String(value ?? '')
-  return numeric.toFixed(2)
+  if (value === '' || value === null || value === undefined) return '';
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) return String(value ?? '');
+  return numeric.toFixed(2);
 }
 
-export function SalesPlanningGrid({ rows, columnMeta, nestedHeaders, columnKeys, productOptions }: SalesPlanningGridProps) {
-  const hotRef = useRef<Handsontable | null>(null)
-  const pendingRef = useRef<Map<string, SalesUpdate>>(new Map())
-  const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const [focusProductId, setFocusProductId] = useState<string>('ALL')
+export function SalesPlanningGrid({
+  rows,
+  columnMeta,
+  nestedHeaders,
+  columnKeys,
+  productOptions,
+}: SalesPlanningGridProps) {
+  const hotRef = useRef<Handsontable | null>(null);
+  const pendingRef = useRef<Map<string, SalesUpdate>>(new Map());
+  const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [focusProductId, setFocusProductId] = useState<string>('ALL');
 
-  const data = useMemo(() => rows, [rows])
+  const data = useMemo(() => rows, [rows]);
+
+  const focusLabel = useMemo(() => {
+    if (focusProductId === 'ALL') return 'All SKUs';
+    const match = productOptions.find((option) => option.id === focusProductId);
+    return match?.name ?? 'All SKUs';
+  }, [focusProductId, productOptions]);
 
   useEffect(() => {
     if (hotRef.current) {
-      hotRef.current.loadData(data)
+      hotRef.current.loadData(data);
     }
-  }, [data])
+  }, [data]);
 
   const columns: Handsontable.ColumnSettings[] = useMemo(() => {
     const base: Handsontable.ColumnSettings[] = [
       { data: 'weekNumber', readOnly: true, className: 'cell-readonly' },
       { data: 'weekDate', readOnly: true, className: 'cell-readonly' },
-    ]
+    ];
     for (const key of columnKeys) {
-      const meta = columnMeta[key]
+      const meta = columnMeta[key];
       if (!meta) {
-        base.push({ data: key, readOnly: true, className: 'cell-readonly' })
-        continue
+        base.push({ data: key, readOnly: true, className: 'cell-readonly' });
+        continue;
       }
       base.push({
         data: key,
         type: 'numeric',
-        numericFormat: editableMetrics.has(meta.field) ? { pattern: '0,0.00' } : { pattern: '0.00' },
+        numericFormat: editableMetrics.has(meta.field)
+          ? { pattern: '0,0.00' }
+          : { pattern: '0.00' },
         readOnly: !editableMetrics.has(meta.field),
         className: editableMetrics.has(meta.field) ? 'cell-editable' : 'cell-readonly',
-      })
+      });
     }
-    return base
-  }, [columnMeta, columnKeys])
+    return base;
+  }, [columnMeta, columnKeys]);
 
   const hiddenColumns = useMemo(() => {
-    if (focusProductId === 'ALL') return []
-    const hidden: number[] = []
-    const offset = 2
+    if (focusProductId === 'ALL') return [];
+    const hidden: number[] = [];
+    const offset = 2;
     columnKeys.forEach((key, index) => {
-      const meta = columnMeta[key]
-      if (!meta) return
+      const meta = columnMeta[key];
+      if (!meta) return;
       if (meta.productId !== focusProductId) {
-        hidden.push(index + offset)
+        hidden.push(index + offset);
       }
-    })
-    return hidden
-  }, [columnKeys, columnMeta, focusProductId])
+    });
+    return hidden;
+  }, [columnKeys, columnMeta, focusProductId]);
 
   const flush = () => {
-    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current)
+    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current);
     flushTimeoutRef.current = setTimeout(async () => {
-      const payload = Array.from(pendingRef.current.values())
-      if (payload.length === 0) return
-      pendingRef.current.clear()
+      const payload = Array.from(pendingRef.current.values());
+      if (payload.length === 0) return;
+      pendingRef.current.clear();
       try {
         const response = await fetch('/api/v1/x-plan/sales-weeks', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ updates: payload }),
-        })
-        if (!response.ok) throw new Error('Failed to update sales planning')
-        toast.success('Sales planning updated')
+        });
+        if (!response.ok) throw new Error('Failed to update sales planning');
+        toast.success('Sales planning updated');
       } catch (error) {
-        console.error(error)
-        toast.error('Unable to save sales planning changes')
+        console.error(error);
+        toast.error('Unable to save sales planning changes');
       }
-    }, 600)
-  }
+    }, 600);
+  };
 
   return (
-    <div className="space-y-3 p-4">
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            3. Sales Planning
+    <GridSurface>
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-2">
+          <p className="text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-slate-400">
+            Step 3
+          </p>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-50">
+            Sales Planning Horizon
           </h2>
-          <label className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
-            <span>Focus SKU</span>
-            <select
-              value={focusProductId}
-              onChange={(event) => setFocusProductId(event.target.value)}
-              className="rounded-md border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
-            >
-              <option value="ALL">Show all</option>
-              {productOptions.map((option) => (
-                <option key={option.id} value={option.id}>
-                  {option.name}
-                </option>
-              ))}
-            </select>
-          </label>
+          <p className="max-w-3xl text-sm text-slate-500 dark:text-slate-400">
+            Plan actuals vs forecast for every SKU-week. Filter to a single product when you want a
+            cleaner runway view—the grid still keeps your totals balanced in the background.
+          </p>
+          <div className="flex flex-wrap items-center gap-2 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+            <span className="inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white/80 px-3 py-1 text-slate-600 shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200">
+              {data.length} calendar weeks
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white/80 px-3 py-1 text-slate-600 shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200">
+              {productOptions.length} SKUs
+            </span>
+          </div>
+        </div>
+        <div className="flex flex-col gap-3 rounded-2xl border border-slate-200/70 bg-white/70 p-4 text-xs text-slate-600 shadow-sm dark:border-white/10 dark:bg-slate-950/50 dark:text-slate-300">
+          <div className="flex items-center justify-between gap-3">
+            <span className="font-semibold text-slate-700 dark:text-slate-100">Focus SKU</span>
+            <span className="rounded-full border border-slate-200/70 bg-white/80 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-slate-500 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-300">
+              {focusLabel}
+            </span>
+          </div>
+          <select
+            value={focusProductId}
+            onChange={(event) => setFocusProductId(event.target.value)}
+            className="rounded-xl border border-slate-300/70 bg-white/90 px-3 py-2 text-xs font-medium text-slate-600 shadow-sm transition focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-400/40 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100"
+          >
+            <option value="ALL">Show every SKU</option>
+            {productOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.name}
+              </option>
+            ))}
+          </select>
+          <p className="text-[0.65rem] leading-5 text-slate-500 dark:text-slate-400">
+            Hiding other columns just tucks them out of view—you&apos;re still updating the overall
+            demand plan.
+          </p>
         </div>
       </div>
-      <HotTable
-        ref={(instance) => {
-          hotRef.current = instance?.hotInstance ?? null
-        }}
-        data={data}
-        licenseKey="non-commercial-and-evaluation"
-        colHeaders={false}
-        columns={columns}
-        nestedHeaders={nestedHeaders}
-        stretchH="all"
-        className="x-plan-hot"
-        height="auto"
-        rowHeaders={false}
-        dropdownMenu
-        filters
-        hiddenColumns={{ columns: hiddenColumns, indicators: true }}
-        afterChange={(changes, source) => {
-          if (!changes || source === 'loadData') return
-          const hot = hotRef.current
-          if (!hot) return
-          for (const change of changes) {
-            const [rowIndex, prop, _oldValue, newValue] = change as [number, string, any, any]
-            const meta = columnMeta[prop]
-            if (!meta || !editableMetrics.has(meta.field)) continue
-            const record = hot.getSourceDataAtRow(rowIndex) as SalesRow | null
-            if (!record) continue
-            const key = `${meta.productId}-${record.weekNumber}`
-            if (!pendingRef.current.has(key)) {
-              pendingRef.current.set(key, {
-                productId: meta.productId,
-                weekNumber: Number(record.weekNumber),
-                values: {},
-              })
+
+      <GridLegend />
+
+      <div className="x-plan-grid-shell">
+        <HotTable
+          ref={(instance) => {
+            hotRef.current = instance?.hotInstance ?? null;
+          }}
+          data={data}
+          licenseKey="non-commercial-and-evaluation"
+          colHeaders={false}
+          columns={columns}
+          nestedHeaders={nestedHeaders}
+          stretchH="all"
+          className="x-plan-hot"
+          height="auto"
+          rowHeaders={false}
+          dropdownMenu
+          filters
+          hiddenColumns={{ columns: hiddenColumns, indicators: true }}
+          afterChange={(changes, source) => {
+            if (!changes || source === 'loadData') return;
+            const hot = hotRef.current;
+            if (!hot) return;
+            for (const change of changes) {
+              const [rowIndex, prop, _oldValue, newValue] = change as [number, string, any, any];
+              const meta = columnMeta[prop];
+              if (!meta || !editableMetrics.has(meta.field)) continue;
+              const record = hot.getSourceDataAtRow(rowIndex) as SalesRow | null;
+              if (!record) continue;
+              const key = `${meta.productId}-${record.weekNumber}`;
+              if (!pendingRef.current.has(key)) {
+                pendingRef.current.set(key, {
+                  productId: meta.productId,
+                  weekNumber: Number(record.weekNumber),
+                  values: {},
+                });
+              }
+              const entry = pendingRef.current.get(key);
+              if (!entry) continue;
+              entry.values[meta.field] = normalizeEditableValue(newValue);
             }
-            const entry = pendingRef.current.get(key)
-            if (!entry) continue
-            entry.values[meta.field] = normalizeEditableValue(newValue)
-          }
-          flush()
-        }}
-      />
-    </div>
-  )
+            flush();
+          }}
+        />
+      </div>
+    </GridSurface>
+  );
 }

--- a/apps/x-plan/styles/handsontable-theme.css
+++ b/apps/x-plan/styles/handsontable-theme.css
@@ -1,3 +1,49 @@
+.x-plan-grid-surface {
+  --hot-background: rgba(248, 250, 252, 0.88);
+}
+
+.dark .x-plan-grid-surface {
+  --hot-background: rgba(15, 23, 42, 0.88);
+}
+
+.x-plan-grid-shell {
+  position: relative;
+  overflow: hidden;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(241, 245, 249, 0.88));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.x-plan-grid-shell::before {
+  content: '';
+  position: absolute;
+  inset: -40% -10% auto -10%;
+  height: 55%;
+  background: radial-gradient(circle at top, rgba(99, 102, 241, 0.18), transparent 70%);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.dark .x-plan-grid-shell {
+  border-color: rgba(71, 85, 105, 0.7);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.82));
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12);
+}
+
+.dark .x-plan-grid-shell::before {
+  background: radial-gradient(circle at top, rgba(129, 140, 248, 0.28), transparent 70%);
+}
+
+.x-plan-grid-shell .handsontable {
+  background: transparent;
+}
+
+.x-plan-grid-shell .wtHolder,
+.x-plan-grid-shell .ht_master table {
+  background: transparent;
+}
+
 .x-plan-hot .ht_clone_master .wtHolder {
   background-color: var(--hot-background, #ffffff);
 }
@@ -5,7 +51,11 @@
 .x-plan-hot .htCore th,
 .x-plan-hot .htCore td {
   font-size: 13px;
+  line-height: 1.55;
   color: #0f172a;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
 }
 
 .dark .x-plan-hot .htCore th,
@@ -14,38 +64,48 @@
 }
 
 .x-plan-hot .htCore thead th {
-  background-color: #f8fafc;
+  background-image: linear-gradient(120deg, rgba(99, 102, 241, 0.16), rgba(236, 72, 153, 0.12));
+  color: #0f172a;
+  font-size: 11px;
   font-weight: 600;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  letter-spacing: 0.02em;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
 }
 
 .dark .x-plan-hot .htCore thead th {
-  background-color: #1e293b;
+  background-image: linear-gradient(120deg, rgba(129, 140, 248, 0.26), rgba(236, 72, 153, 0.2));
+  color: #f8fafc;
+  border-bottom-color: rgba(71, 85, 105, 0.7);
 }
 
 .x-plan-hot .htCore td {
-  border-color: #e2e8f0;
+  border-color: rgba(148, 163, 184, 0.28);
+  background-color: transparent;
 }
 
 .dark .x-plan-hot .htCore td {
-  border-color: #334155;
+  border-color: rgba(71, 85, 105, 0.65);
 }
 
-.x-plan-hot .cell-editable { background-color: rgba(20, 148, 223, 0.14); color: #0f172a; }
+.x-plan-hot .cell-editable {
+  background-image: linear-gradient(135deg, rgba(56, 189, 248, 0.2), rgba(99, 102, 241, 0.16));
+  color: #0f172a;
+}
 
-.dark .x-plan-hot .cell-editable { background-color: rgba(20, 148, 223, 0.14); color: #0f172a; }
+.dark .x-plan-hot .cell-editable {
+  background-image: linear-gradient(135deg, rgba(56, 189, 248, 0.28), rgba(129, 140, 248, 0.22));
+  color: #e2e8f0;
+}
 
 .x-plan-hot .cell-readonly {
-  background-color: #f8fafc;
+  background-image: linear-gradient(135deg, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.08));
   color: #475569;
 }
 
-
-
-.x-plan-hot .area {
-  background: rgba(59, 130, 246, 0.15);
-  border: 1px solid rgba(59, 130, 246, 0.6);
+.dark .x-plan-hot .cell-readonly {
+  background-image: linear-gradient(135deg, rgba(51, 65, 85, 0.6), rgba(51, 65, 85, 0.35));
+  color: #cbd5f5;
 }
 
 .x-plan-hot .htDimmed {
@@ -56,19 +116,35 @@
   color: #94a3b8;
 }
 
+.x-plan-hot .area {
+  background: rgba(99, 102, 241, 0.18);
+  border: 1px solid rgba(99, 102, 241, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.18);
+}
+
 .x-plan-hot .wtBorder.current {
-  border: 2px solid #2563eb;
+  border: 2px solid rgba(236, 72, 153, 0.8);
+  box-shadow: 0 0 0 3px rgba(236, 72, 153, 0.25);
 }
 
 .x-plan-hot .row-active {
-  background-color: #eef2ff !important;
+  background-image: linear-gradient(
+    90deg,
+    rgba(129, 140, 248, 0.28),
+    rgba(59, 130, 246, 0.12)
+  ) !important;
   color: #1e1b4b !important;
 }
 
 .dark .x-plan-hot .row-active {
-  background-color: rgba(129, 140, 248, 0.2) !important;
+  background-image: linear-gradient(
+    90deg,
+    rgba(129, 140, 248, 0.35),
+    rgba(59, 130, 246, 0.18)
+  ) !important;
   color: #e0e7ff !important;
 }
 
-.x-plan-hot .cell-readonly { background-color: rgba(15, 23, 42, 0.04); color: #475569; }
-.dark .x-plan-hot .cell-readonly { background-color: rgba(148, 163, 184, 0.08); color: #e2e8f0; }
+.x-plan-hot .ht_master .wtBorder.corner {
+  display: none;
+}

--- a/apps/x-plan/tsconfig.json
+++ b/apps/x-plan/tsconfig.json
@@ -30,6 +30,10 @@
       {
         "name": "next"
       }
+    ],
+    "types": [
+      "vitest/globals",
+      "@testing-library/jest-dom"
     ]
   },
   "include": [


### PR DESCRIPTION
## Summary
- add a reusable `GridSurface` shell and bring `GridLegend` to life with navigation tips so every grid shares the same chrome
- restyle the product, sales, ops, and finance Handsontable sheets with descriptive headers, chips, and call-to-action copy
- refresh the Handsontable theme with gradients/tints and register vitest DOM types for the updated UI suite

## Testing
- pnpm --filter @ecom-os/x-plan lint
- pnpm --filter @ecom-os/x-plan type-check

------
https://chatgpt.com/codex/tasks/task_e_68d357e9c8508321932d02b1a6b2f396