### PR TITLE
x-plan: align finance assumptions grid in product setup

### DIFF
--- a/apps/x-plan/components/sheets/product-setup-grid.tsx
+++ b/apps/x-plan/components/sheets/product-setup-grid.tsx
@@ -146,7 +146,7 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
   }
 
   return (
-    <div className="space-y-4 p-4">
+    <section className="space-y-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
       <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Product Pricing & Costs</h2>
       <HotTable
         ref={(instance) => {
@@ -196,6 +196,6 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
           queueFlush()
         }}
       />
-    </div>
+    </section>
   )
 }

--- a/apps/x-plan/components/sheets/product-setup-panels.tsx
+++ b/apps/x-plan/components/sheets/product-setup-panels.tsx
@@ -1,7 +1,14 @@
 'use client'
 
-import { useEffect, useRef, useState, type ChangeEvent } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
+import { HotTable } from '@handsontable/react'
+import Handsontable from 'handsontable'
+import { registerAllModules } from 'handsontable/registry'
+import 'handsontable/dist/handsontable.full.min.css'
+import '@/styles/handsontable-theme.css'
 import { toast } from 'sonner'
+
+registerAllModules()
 
 interface BusinessParameter {
   id: string
@@ -10,30 +17,62 @@ interface BusinessParameter {
   type: 'numeric' | 'text'
 }
 
-export function BusinessParametersPanel({ parameters }: { parameters: BusinessParameter[] }) {
-  const [rows, setRows] = useState(parameters)
+type BusinessParameterUpdate = { id: string; valueNumeric?: string; valueText?: string }
+
+function toCellValue(value: unknown) {
+  if (value === null || value === undefined) return ''
+  return String(value)
+}
+
+export function ProductSetupFinancePanel({ parameters }: { parameters: BusinessParameter[] }) {
+  const hotRef = useRef<Handsontable | null>(null)
   const pendingRef = useRef<Map<string, string>>(new Map())
   const flushTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
-  useEffect(() => {
-    setRows(parameters)
-  }, [parameters])
+  const data = useMemo<BusinessParameter[]>(() => parameters.map((parameter) => ({ ...parameter })), [parameters])
 
-  const flush = () => {
+  useEffect(() => {
+    if (hotRef.current) {
+      hotRef.current.loadData(data)
+    }
+    pendingRef.current.clear()
+    if (flushTimeoutRef.current) {
+      clearTimeout(flushTimeoutRef.current)
+      flushTimeoutRef.current = null
+    }
+  }, [data])
+
+  useEffect(() => {
+    return () => {
+      if (flushTimeoutRef.current) {
+        clearTimeout(flushTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const queueFlush = () => {
     if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current)
     flushTimeoutRef.current = setTimeout(async () => {
-      const payload: Array<{ id: string; valueNumeric?: string; valueText?: string }> = []
+      const hot = hotRef.current
+      const rows = hot?.getSourceData() as BusinessParameter[] | undefined
+      const payload: BusinessParameterUpdate[] = []
+
       for (const [id, value] of pendingRef.current.entries()) {
-        const parameter = rows.find((item) => item.id === id)
-        if (!parameter) continue
-        if (parameter.type === 'numeric') {
+        const row = rows?.find((item) => item.id === id)
+        if (!row) continue
+        if (row.type === 'numeric') {
           payload.push({ id, valueNumeric: value })
         } else {
           payload.push({ id, valueText: value })
         }
       }
 
-      if (payload.length === 0) return
+      if (payload.length === 0) {
+        pendingRef.current.clear()
+        flushTimeoutRef.current = null
+        return
+      }
+
       pendingRef.current.clear()
 
       try {
@@ -43,62 +82,90 @@ export function BusinessParametersPanel({ parameters }: { parameters: BusinessPa
           body: JSON.stringify({ updates: payload }),
         })
         if (!response.ok) throw new Error('Failed to update parameters')
-        setRows((previous) =>
-          previous.map((row) => {
-            const update = payload.find((item) => item.id === row.id)
-            if (!update) return row
-            if (row.type === 'numeric') {
-              const numericValue = Number(update.valueNumeric ?? row.value)
-              if (Number.isNaN(numericValue)) return row
-              return { ...row, value: numericValue.toFixed(2) }
-            }
-            return row
+
+        if (hot && rows) {
+          payload.forEach((update) => {
+            if (!('valueNumeric' in update)) return
+            const rowIndex = rows.findIndex((row) => row.id === update.id)
+            if (rowIndex === -1) return
+            const numericValue = Number(update.valueNumeric)
+            if (Number.isNaN(numericValue)) return
+            const formatted = numericValue.toFixed(2)
+            rows[rowIndex].value = formatted
+            hot.setDataAtRowProp(rowIndex, 'value', formatted, 'normalize-update')
           })
-        )
+        }
+
         toast.success('Business parameters updated')
       } catch (error) {
         console.error(error)
         toast.error('Unable to update business parameters')
+      } finally {
+        flushTimeoutRef.current = null
       }
     }, 400)
   }
 
-  const handleChange = (id: string) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { value } = event.target
-    setRows((previous) => previous.map((row) => (row.id === id ? { ...row, value } : row)))
-    pendingRef.current.set(id, value)
-  }
-
-  const handleBlur = () => {
-    flush()
-  }
+  if (parameters.length === 0) return null
 
   return (
-    <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <header className="mb-4">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Business Parameters</h3>
-        <p className="text-xs text-slate-500 dark:text-slate-400">Global assumptions that flow into every sheet.</p>
-      </header>
-      <div className="space-y-2">
-        {rows.map((parameter) => (
-          <div
-            key={parameter.id}
-            className="flex flex-col gap-1 rounded-lg bg-slate-50 px-3 py-2 text-sm dark:bg-slate-800"
-          >
-            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              {parameter.label}
-            </label>
-            <input
-              value={parameter.value}
-              onChange={handleChange(parameter.id)}
-              onBlur={handleBlur}
-              type={parameter.type === 'numeric' ? 'number' : 'text'}
-              step={parameter.type === 'numeric' ? '0.01' : undefined}
-              className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-slate-500 dark:focus:ring-slate-800"
-            />
-          </div>
-        ))}
+    <div className="space-y-4 p-4">
+      <div className="space-y-1">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Finance</h2>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          Set the cash assumptions that feed every financial plan.
+        </p>
       </div>
-    </section>
+      <HotTable
+        ref={(instance) => {
+          hotRef.current = instance?.hotInstance ?? null
+        }}
+        data={data}
+        licenseKey="non-commercial-and-evaluation"
+        colHeaders={['Parameter', 'Value']}
+        columns={[
+          { data: 'label', readOnly: true, className: 'cell-readonly htLeft' },
+          { data: 'value', className: 'cell-editable' },
+        ]}
+        rowHeaders={false}
+        height="auto"
+        stretchH="all"
+        className="x-plan-hot"
+        dropdownMenu
+        filters
+        afterGetColHeader={(col, TH) => {
+          if (col === 0) TH.classList.add('htLeft')
+        }}
+        cells={(row, col) => {
+          const cellProperties: Handsontable.CellProperties = {}
+          if (col === 1) {
+            const record = data[row]
+            if (record?.type === 'numeric') {
+              cellProperties.type = 'numeric'
+              cellProperties.numericFormat = { pattern: '0,0.00' }
+              cellProperties.className = 'cell-editable htRight'
+            }
+          }
+          return cellProperties
+        }}
+        afterChange={(changes, source) => {
+          const changeSource = String(source)
+          if (!changes || changeSource === 'loadData' || changeSource === 'normalize-update') return
+          const hot = hotRef.current
+          if (!hot) return
+          const rows = hot.getSourceData() as BusinessParameter[]
+          for (const change of changes) {
+            const [rowIndex, prop, _oldValue, newValue] = change as [number, keyof BusinessParameter, any, any]
+            if (prop !== 'value') continue
+            const row = rows[rowIndex]
+            if (!row) continue
+            const value = toCellValue(newValue)
+            row.value = value
+            pendingRef.current.set(row.id, value)
+          }
+          queueFlush()
+        }}
+      />
+    </div>
   )
 }

--- a/apps/x-plan/components/sheets/product-setup-panels.tsx
+++ b/apps/x-plan/components/sheets/product-setup-panels.tsx
@@ -24,7 +24,17 @@ function toCellValue(value: unknown) {
   return String(value)
 }
 
-export function ProductSetupFinancePanel({ parameters }: { parameters: BusinessParameter[] }) {
+interface ProductSetupParametersSectionProps {
+  title: string
+  description?: string
+  parameters: BusinessParameter[]
+}
+
+export function ProductSetupParametersSection({
+  title,
+  description,
+  parameters,
+}: ProductSetupParametersSectionProps) {
   const hotRef = useRef<Handsontable | null>(null)
   const pendingRef = useRef<Map<string, string>>(new Map())
   const flushTimeoutRef = useRef<NodeJS.Timeout | null>(null)
@@ -109,12 +119,12 @@ export function ProductSetupFinancePanel({ parameters }: { parameters: BusinessP
   if (parameters.length === 0) return null
 
   return (
-    <div className="space-y-4 p-4">
+    <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
       <div className="space-y-1">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Finance</h2>
-        <p className="text-xs text-slate-500 dark:text-slate-400">
-          Set the cash assumptions that feed every financial plan.
-        </p>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{title}</h2>
+        {description ? (
+          <p className="text-xs text-slate-500 dark:text-slate-400">{description}</p>
+        ) : null}
       </div>
       <HotTable
         ref={(instance) => {


### PR DESCRIPTION
## Summary
- replace the finance assumptions panel with a Handsontable grid so the context pane matches the product setup table styling
- keep inline editing with batched API updates and normalize numeric values after saves

## Testing
- pnpm lint *(fails: `next` not found in workspace because dependencies cannot be installed in this environment)*
- pnpm --filter @ecom-os/x-plan lint *(fails: `next` binary missing without installing workspace dependencies)*
- pnpm --filter @ecom-os/x-plan type-check *(fails: missing React/Vitest/date-fns modules since node_modules is absent)*

------
https://chatgpt.com/codex/tasks/task_e_68d359e592448321b2b11316b0eafad2