### PR TITLE
x-plan: streamline product setup grid inputs

### DIFF
--- a/apps/x-plan/app/sheet/[sheet]/page.tsx
+++ b/apps/x-plan/app/sheet/[sheet]/page.tsx
@@ -25,7 +25,6 @@ import {
   mapCashFlowWeeks,
 } from '@/lib/calculations/adapters'
 import {
-  computeProductCostSummary,
   buildProductCostIndex,
   buildLeadTimeProfiles,
   getLeadTimeProfile,
@@ -193,23 +192,20 @@ async function getProductSetupView() {
   )
 
   const filteredProducts = productInputs.filter((product) => !excludedNames.has(product.name.toLowerCase()))
-  const productSummaries = filteredProducts.map((product) => computeProductCostSummary(product))
 
   return {
-    products: productSummaries.map((summary) => ({
-      id: summary.id,
-      name: summary.name,
-      sellingPrice: formatNumeric(summary.sellingPrice),
-      manufacturingCost: formatNumeric(summary.manufacturingCost),
-      freightCost: formatNumeric(summary.freightCost),
-      tariffRate: formatPercentDecimal(summary.tariffRate),
-      tacosPercent: formatPercentDecimal(summary.tacosPercent),
-      fbaFee: formatNumeric(summary.fbaFee),
-      amazonReferralRate: formatPercentDecimal(summary.amazonReferralRate),
-      storagePerMonth: formatNumeric(summary.storagePerMonth),
-      landedCost: formatNumeric(summary.landedUnitCost),
-      grossContribution: formatNumeric(summary.grossContribution),
-      grossMarginPercent: summary.grossMarginPercent.toFixed(4),
+    products: filteredProducts.map((product) => ({
+      id: product.id,
+      name: product.name,
+      sku: product.sku ?? '',
+      sellingPrice: formatNumeric(product.sellingPrice),
+      manufacturingCost: formatNumeric(product.manufacturingCost),
+      freightCost: formatNumeric(product.freightCost),
+      tariffRate: formatPercentDecimal(product.tariffRate),
+      tacosPercent: formatPercentDecimal(product.tacosPercent),
+      fbaFee: formatNumeric(product.fbaFee),
+      amazonReferralRate: formatPercentDecimal(product.amazonReferralRate),
+      storagePerMonth: formatNumeric(product.storagePerMonth),
     })),
   }
 }


### PR DESCRIPTION
## Summary
- remove redundant derived metrics from the Product Setup grid, add an SKU column, and simplify update normalization
- update the sheet loader to supply SKU data and align with the leaner grid payload

## Testing
- `pnpm lint` *(fails: Next.js CLI binary missing because workspace dependencies cannot be installed in this environment)*
- `pnpm typecheck` *(fails: workspace packages cannot complete TypeScript checks without installing dependencies)*
- `pnpm --filter @ecom-os/x-plan exec tsc --noEmit` *(fails: package-level dependencies are unavailable under the current install constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68d35936c85083218f96bf3c7a77e27a