### PR TITLE
fix(x-plan): align handsontable styling with brand palette

### DIFF
--- a/apps/x-plan/components/grid-legend.tsx
+++ b/apps/x-plan/components/grid-legend.tsx
@@ -1,3 +1,48 @@
-export function GridLegend() {
-  return null
+interface GridLegendProps {
+  className?: string
+}
+
+const LEGEND_ITEMS = [
+  {
+    id: 'input',
+    label: 'Editable input',
+    description: 'Type to update the plan',
+    swatchClass: 'bg-[#00C2B9] dark:bg-teal-400',
+  },
+  {
+    id: 'calculated',
+    label: 'Calculated output',
+    description: 'Updates from workbook logic',
+    swatchClass: 'bg-slate-300 dark:bg-slate-500',
+  },
+  {
+    id: 'active',
+    label: 'Linked row',
+    description: 'Feeds the detail drawer',
+    swatchClass: 'bg-teal-600 dark:bg-teal-400',
+  },
+] as const
+
+export function GridLegend({ className }: GridLegendProps) {
+  const baseClass =
+    'flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-slate-500 dark:text-slate-400'
+
+  return (
+    <div className={className ? `${baseClass} ${className}` : baseClass} aria-label="Grid legend">
+      {LEGEND_ITEMS.map((item) => (
+        <div key={item.id} className="flex items-center gap-2">
+          <span aria-hidden className={`h-2.5 w-2.5 rounded-full ${item.swatchClass}`} />
+          <span className="font-medium text-slate-600 dark:text-slate-200">{item.label}</span>
+          {item.description ? (
+            <>
+              <span className="sr-only"> — {item.description}</span>
+              <span aria-hidden className="hidden text-slate-400 dark:text-slate-500 sm:inline">
+                · {item.description}
+              </span>
+            </>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  )
 }

--- a/apps/x-plan/components/sheets/ops-planning-grid.tsx
+++ b/apps/x-plan/components/sheets/ops-planning-grid.tsx
@@ -151,9 +151,15 @@ export function OpsPlanningGrid({ rows, activeOrderId, onSelectOrder, onRowsChan
 
   return (
     <section className="space-y-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-        Lead & Schedule Inputs
-      </h2>
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Lead &amp; schedule inputs
+        </h2>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          Update production timing and statuses — the highlighted row stays in sync with the detail view.
+        </p>
+      </div>
+      <GridLegend />
       <HotTable
         ref={(instance) => {
           hotRef.current = instance?.hotInstance ?? null

--- a/apps/x-plan/components/sheets/ops-planning-timeline.tsx
+++ b/apps/x-plan/components/sheets/ops-planning-timeline.tsx
@@ -52,7 +52,7 @@ export function OpsPlanningTimelineTable({ rows, activeOrderId, onSelectOrder }:
       </header>
       <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-slate-200 text-sm text-slate-600 dark:divide-slate-800 dark:text-slate-200">
-          <thead className="bg-slate-50 text-xs uppercase tracking-[0.12em] text-slate-400 dark:bg-slate-800 dark:text-slate-500">
+          <thead className="bg-[#00C2B9]/10 text-xs uppercase tracking-[0.08em] text-slate-600 dark:bg-slate-800/60 dark:text-slate-300">
             <tr>
               {HEADERS.map((header) => (
                 <th key={header} className="px-3 py-2 text-left font-semibold">
@@ -69,8 +69,8 @@ export function OpsPlanningTimelineTable({ rows, activeOrderId, onSelectOrder }:
                   key={row.id}
                   onClick={() => onSelectOrder?.(row.id)}
                   className={clsx(
-                    'cursor-pointer bg-white transition hover:bg-slate-100 dark:bg-slate-900 dark:hover:bg-slate-800',
-                    isActive && 'bg-indigo-50/80 dark:bg-indigo-500/10'
+                    'cursor-pointer bg-white transition hover:bg-[#00C2B9]/10 dark:bg-slate-900 dark:hover:bg-slate-800',
+                    isActive && 'bg-[#CCF7F3] dark:bg-teal-500/15'
                   )}
                 >
                   <td className="px-3 py-2 font-medium text-slate-700 dark:text-slate-100">{row.orderCode}</td>

--- a/apps/x-plan/components/sheets/product-setup-grid.tsx
+++ b/apps/x-plan/components/sheets/product-setup-grid.tsx
@@ -147,7 +147,15 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
 
   return (
     <div className="space-y-4 p-4">
-      <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Product Pricing & Costs</h2>
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Product pricing &amp; costs
+        </h2>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          Tune each SKU’s inputs to keep landed cost and margin outputs current.
+        </p>
+      </div>
+      <GridLegend />
       <HotTable
         ref={(instance) => {
           hotRef.current = instance?.hotInstance ?? null

--- a/apps/x-plan/components/sheets/purchase-payments-grid.tsx
+++ b/apps/x-plan/components/sheets/purchase-payments-grid.tsx
@@ -156,19 +156,22 @@ export function PurchasePaymentsGrid({ payments, activeOrderId, onSelectOrder, o
 
   return (
     <div className="space-y-3 p-4">
-      <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Supplier Payments</h2>
-        <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+      <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Supplier payments
+        </h2>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
           {summaryText && <span>{summaryText}</span>}
           <button
             onClick={onAddPayment}
             disabled={!activeOrderId || isLoading || isFullyAllocated}
             className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 transition enabled:hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:enabled:hover:bg-slate-800"
           >
-            Add Payment
+            Add payment
           </button>
         </div>
       </div>
+      <GridLegend />
       <HotTable
         ref={(instance) => {
           hotRef.current = instance?.hotInstance ?? null

--- a/apps/x-plan/components/sheets/sales-planning-grid.tsx
+++ b/apps/x-plan/components/sheets/sales-planning-grid.tsx
@@ -117,27 +117,31 @@ export function SalesPlanningGrid({ rows, columnMeta, nestedHeaders, columnKeys,
   return (
     <div className="space-y-3 p-4">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-1">
           <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            3. Sales Planning
+            3. Sales planning
           </h2>
-          <label className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
-            <span>Focus SKU</span>
-            <select
-              value={focusProductId}
-              onChange={(event) => setFocusProductId(event.target.value)}
-              className="rounded-md border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
-            >
-              <option value="ALL">Show all</option>
-              {productOptions.map((option) => (
-                <option key={option.id} value={option.id}>
-                  {option.name}
-                </option>
-              ))}
-            </select>
-          </label>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Use the focus filter to isolate one SKU while keeping weekly totals intact.
+          </p>
         </div>
+        <label className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+          <span>Focus SKU</span>
+          <select
+            value={focusProductId}
+            onChange={(event) => setFocusProductId(event.target.value)}
+            className="rounded-md border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+          >
+            <option value="ALL">Show all</option>
+            {productOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.name}
+              </option>
+            ))}
+          </select>
+        </label>
       </div>
+      <GridLegend />
       <HotTable
         ref={(instance) => {
           hotRef.current = instance?.hotInstance ?? null

--- a/apps/x-plan/styles/handsontable-theme.css
+++ b/apps/x-plan/styles/handsontable-theme.css
@@ -1,51 +1,78 @@
-.x-plan-hot .ht_clone_master .wtHolder {
-  background-color: var(--hot-background, #ffffff);
+.x-plan-hot {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+  background-color: #ffffff;
+}
+
+.dark .x-plan-hot {
+  border-color: rgba(148, 163, 184, 0.3);
+  background-color: rgba(15, 23, 42, 0.88);
+}
+
+.x-plan-hot .ht_clone_master .wtHolder,
+.x-plan-hot .ht_clone_top .wtHolder,
+.x-plan-hot .ht_clone_left .wtHolder,
+.x-plan-hot .ht_clone_top_left_corner .wtHolder {
+  background-color: transparent;
+}
+
+.x-plan-hot .htCore {
+  background-color: transparent;
 }
 
 .x-plan-hot .htCore th,
 .x-plan-hot .htCore td {
   font-size: 13px;
   color: #0f172a;
+  border-color: rgba(15, 23, 42, 0.08);
 }
 
 .dark .x-plan-hot .htCore th,
 .dark .x-plan-hot .htCore td {
   color: #e2e8f0;
+  border-color: rgba(148, 163, 184, 0.25);
 }
 
 .x-plan-hot .htCore thead th {
-  background-color: #f8fafc;
+  background-color: #f1faf9;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
+  color: #0f172a;
 }
 
 .dark .x-plan-hot .htCore thead th {
-  background-color: #1e293b;
+  background-color: rgba(15, 23, 42, 0.82);
+  color: #cbd5f5;
 }
 
-.x-plan-hot .htCore td {
-  border-color: #e2e8f0;
+.x-plan-hot .htCore tbody tr:nth-child(even) td:not(.cell-editable):not(.row-active) {
+  background-color: rgba(15, 23, 42, 0.02);
 }
 
-.dark .x-plan-hot .htCore td {
-  border-color: #334155;
+.dark .x-plan-hot .htCore tbody tr:nth-child(even) td:not(.cell-editable):not(.row-active) {
+  background-color: rgba(148, 163, 184, 0.12);
 }
 
-.x-plan-hot .cell-editable { background-color: rgba(20, 148, 223, 0.14); color: #0f172a; }
+.x-plan-hot .cell-editable {
+  background-color: rgba(0, 194, 185, 0.16);
+  color: #0f172a;
+}
 
-.dark .x-plan-hot .cell-editable { background-color: rgba(20, 148, 223, 0.14); color: #0f172a; }
+.dark .x-plan-hot .cell-editable {
+  background-color: rgba(13, 148, 136, 0.3);
+  color: #ecfeff;
+}
 
 .x-plan-hot .cell-readonly {
   background-color: #f8fafc;
   color: #475569;
 }
 
-
-
-.x-plan-hot .area {
-  background: rgba(59, 130, 246, 0.15);
-  border: 1px solid rgba(59, 130, 246, 0.6);
+.dark .x-plan-hot .cell-readonly {
+  background-color: rgba(148, 163, 184, 0.14);
+  color: #e2e8f0;
 }
 
 .x-plan-hot .htDimmed {
@@ -56,19 +83,74 @@
   color: #94a3b8;
 }
 
-.x-plan-hot .wtBorder.current {
-  border: 2px solid #2563eb;
-}
-
 .x-plan-hot .row-active {
-  background-color: #eef2ff !important;
-  color: #1e1b4b !important;
+  background-color: rgba(14, 116, 144, 0.18) !important;
+  color: #0f172a !important;
+  box-shadow: inset 3px 0 0 rgba(0, 194, 185, 0.45);
 }
 
 .dark .x-plan-hot .row-active {
-  background-color: rgba(129, 140, 248, 0.2) !important;
-  color: #e0e7ff !important;
+  background-color: rgba(13, 148, 136, 0.28) !important;
+  color: #f0fdfa !important;
+  box-shadow: inset 3px 0 0 rgba(45, 212, 191, 0.35);
 }
 
-.x-plan-hot .cell-readonly { background-color: rgba(15, 23, 42, 0.04); color: #475569; }
-.dark .x-plan-hot .cell-readonly { background-color: rgba(148, 163, 184, 0.08); color: #e2e8f0; }
+.x-plan-hot .area {
+  background: rgba(0, 194, 185, 0.2);
+  border: 1px solid rgba(13, 148, 136, 0.55);
+}
+
+.x-plan-hot .wtBorder.current {
+  border: 2px solid rgba(13, 148, 136, 0.85);
+}
+
+.x-plan-hot .fillBorder,
+.x-plan-hot .wtBorder.corner {
+  background: rgba(13, 148, 136, 0.85);
+}
+
+.handsontableInput {
+  border-radius: 0.5rem !important;
+  border: 1px solid rgba(13, 148, 136, 0.35) !important;
+  padding: 0.25rem 0.5rem !important;
+  box-shadow: none !important;
+  font-size: 13px !important;
+  color: #0f172a !important;
+}
+
+.dark .handsontableInput {
+  background-color: rgba(15, 23, 42, 0.92) !important;
+  color: #f0fdfa !important;
+  border-color: rgba(45, 212, 191, 0.4) !important;
+}
+
+.htMenu {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 12px 24px -12px rgba(15, 23, 42, 0.45);
+  background-color: #ffffff;
+}
+
+.dark .htMenu {
+  border-color: rgba(148, 163, 184, 0.25);
+  background-color: rgba(15, 23, 42, 0.92);
+}
+
+.htMenu .htCore td {
+  font-size: 13px;
+  color: #0f172a;
+}
+
+.dark .htMenu .htCore td {
+  color: #e2e8f0;
+}
+
+.htMenu .htCore tr:hover td {
+  background-color: rgba(0, 194, 185, 0.18);
+  color: #0f172a;
+}
+
+.dark .htMenu .htCore tr:hover td {
+  background-color: rgba(13, 148, 136, 0.28);
+  color: #ecfeff;
+}


### PR DESCRIPTION
## Summary
- simplify the shared grid legend into a compact inline treatment that uses the website’s teal accent
- restore the concise headers on the product, ops, sales, and supplier payment sheets while keeping a shared legend for context
- retune the Handsontable theme and ops timeline table with the website palette so editable, read-only, and active states stay consistent

## Testing
- pnpm --filter @ecom-os/x-plan lint *(fails: `next` binary is unavailable because workspace dependencies cannot be installed without registry credentials)*
- pnpm --filter @ecom-os/x-plan type-check *(fails: repo is missing generated Next/Prisma/Vitest types; 691 existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d357e9c8508321932d02b1a6b2f396