### PR TITLE
Harden WMS purchase order normalization and storage ledger updates

### DIFF
--- a/apps/wms/prisma/migrations/20251015000000_purchase_order_scoping/migration.sql
+++ b/apps/wms/prisma/migrations/20251015000000_purchase_order_scoping/migration.sql
@@ -1,0 +1,8 @@
+-- Adjust purchase order uniqueness to scope by warehouse
+DROP INDEX IF EXISTS "purchase_orders_order_number_key";
+CREATE UNIQUE INDEX "purchase_orders_warehouse_code_order_number_key"
+  ON "public"."purchase_orders" ("warehouse_code", "order_number");
+
+-- Prevent duplicate lines with the same SKU and batch on a purchase order
+CREATE UNIQUE INDEX IF NOT EXISTS "purchase_order_lines_purchase_order_id_sku_code_batch_lot_key"
+  ON "public"."purchase_order_lines" ("purchase_order_id", "sku_code", "batch_lot");

--- a/apps/wms/prisma/schema.prisma
+++ b/apps/wms/prisma/schema.prisma
@@ -149,7 +149,7 @@ model InventoryTransaction {
 
 model PurchaseOrder {
   id               String                 @id @default(uuid())
-  orderNumber      String                 @unique @map("order_number")
+  orderNumber      String                 @map("order_number")
   type             PurchaseOrderType
   status           PurchaseOrderStatus    @default(DRAFT)
   warehouseCode    String                 @map("warehouse_code")
@@ -169,6 +169,7 @@ model PurchaseOrder {
 
   @@index([status])
   @@index([type, status])
+  @@unique([warehouseCode, orderNumber])
   @@map("purchase_orders")
 }
 
@@ -190,6 +191,7 @@ model PurchaseOrderLine {
   invoiceLines      WarehouseInvoiceLine[]
 
   @@index([purchaseOrderId])
+  @@unique([purchaseOrderId, skuCode, batchLot])
   @@map("purchase_order_lines")
 }
 

--- a/apps/wms/scripts/setup/purchase-orders.ts
+++ b/apps/wms/scripts/setup/purchase-orders.ts
@@ -137,7 +137,12 @@ async function createPurchaseOrders() {
     }
 
     await prisma.purchaseOrder.upsert({
-      where: { orderNumber: sample.orderNumber },
+      where: {
+        warehouseCode_orderNumber: {
+          warehouseCode: warehouse.code,
+          orderNumber: sample.orderNumber,
+        },
+      },
       update: {
         type: sample.type,
         warehouseCode: warehouse.code,

--- a/apps/wms/src/lib/demo-transactions.ts
+++ b/apps/wms/src/lib/demo-transactions.ts
@@ -290,6 +290,8 @@ export async function createDemoTransactions(config: DemoTransactionConfig) {
           notes: null,
         })
 
+        const normalizedBatchLot = poDetails.batchLot
+
         const transaction = await tx.inventoryTransaction.create({
           data: {
             warehouseCode: plan.warehouse.code,
@@ -303,7 +305,7 @@ export async function createDemoTransactions(config: DemoTransactionConfig) {
             cartonWeightKg: sku.cartonWeightKg,
             packagingType: sku.packagingType,
             unitsPerCarton: sku.unitsPerCarton,
-            batchLot,
+            batchLot: normalizedBatchLot,
             transactionType: 'RECEIVE',
             referenceId: plan.orderNumber,
             cartonsIn: cartons,
@@ -328,7 +330,7 @@ export async function createDemoTransactions(config: DemoTransactionConfig) {
         addInventory({
           warehouse: plan.warehouse,
           sku,
-          batchLot,
+          batchLot: normalizedBatchLot,
           cartons,
           storageCartonsPerPallet,
           shippingCartonsPerPallet,
@@ -434,6 +436,8 @@ export async function createDemoTransactions(config: DemoTransactionConfig) {
           notes: null,
         })
 
+        const normalizedBatchLot = poDetails.batchLot
+
         const transaction = await tx.inventoryTransaction.create({
           data: {
             warehouseCode: plan.warehouse.code,
@@ -447,7 +451,7 @@ export async function createDemoTransactions(config: DemoTransactionConfig) {
             cartonWeightKg: line.sku.cartonWeightKg,
             packagingType: line.sku.packagingType,
             unitsPerCarton: line.sku.unitsPerCarton,
-            batchLot: line.batchLot,
+            batchLot: normalizedBatchLot,
             transactionType: 'SHIP',
             referenceId: plan.orderNumber,
             cartonsIn: 0,
@@ -468,7 +472,7 @@ export async function createDemoTransactions(config: DemoTransactionConfig) {
         })
 
         createdTransactions.push(transaction)
-        decrementInventory(plan.warehouse, line.sku, line.batchLot, line.cartons)
+        decrementInventory(plan.warehouse, line.sku, normalizedBatchLot, line.cartons)
 
         await new Promise(resolve => setTimeout(resolve, 10))
       }
@@ -496,6 +500,8 @@ export async function createDemoTransactions(config: DemoTransactionConfig) {
           notes: null,
         })
 
+        const normalizedBatchLot = poDetails.batchLot
+
         const transaction = await tx.inventoryTransaction.create({
           data: {
             warehouseCode: plan.warehouse.code,
@@ -509,7 +515,7 @@ export async function createDemoTransactions(config: DemoTransactionConfig) {
             cartonWeightKg: line.sku.cartonWeightKg,
             packagingType: line.sku.packagingType,
             unitsPerCarton: line.sku.unitsPerCarton,
-            batchLot: line.batchLot,
+            batchLot: normalizedBatchLot,
             transactionType: 'RECEIVE',
             referenceId: plan.orderNumber,
             cartonsIn: line.cartons,
@@ -532,7 +538,7 @@ export async function createDemoTransactions(config: DemoTransactionConfig) {
         addInventory({
           warehouse: plan.warehouse,
           sku: line.sku,
-          batchLot: line.batchLot,
+          batchLot: normalizedBatchLot,
           cartons: line.cartons,
           storageCartonsPerPallet: line.storageCartonsPerPallet,
           shippingCartonsPerPallet: line.shippingCartonsPerPallet,

--- a/apps/wms/src/lib/services/movement-note-service.ts
+++ b/apps/wms/src/lib/services/movement-note-service.ts
@@ -8,6 +8,7 @@ import {
   TransactionType,
 } from '@prisma/client'
 import { ValidationError, ConflictError, NotFoundError } from '@/lib/api'
+import { resolveBatchLot } from '@/lib/services/purchase-order-service'
 
 export interface UserContext {
   id?: string | null
@@ -243,7 +244,13 @@ export async function postMovementNote(id: string, user: UserContext) {
           cartonWeightKg: sku?.cartonWeightKg ?? null,
           packagingType: sku?.packagingType ?? null,
           unitsPerCarton,
-          batchLot: line.batchLot ?? poLine.batchLot ?? 'UNSPECIFIED',
+          batchLot: resolveBatchLot({
+            rawBatchLot: line.batchLot ?? poLine.batchLot,
+            orderNumber: po.orderNumber,
+            warehouseCode: po.warehouseCode,
+            skuCode: poLine.skuCode,
+            transactionDate: transactionDate,
+          }),
           transactionType,
           referenceId: note.referenceNumber ?? po.orderNumber,
           cartonsIn: isInbound ? line.quantity : 0,

--- a/apps/wms/src/lib/services/transaction-service.ts
+++ b/apps/wms/src/lib/services/transaction-service.ts
@@ -68,6 +68,7 @@ export async function createTransaction(input: CreateTransactionInput) {
       await handleTransactionCosts({
         transactionId: transaction.id,
         warehouseCode: transaction.warehouseCode,
+        warehouseName: transaction.warehouseName,
         skuCode: transaction.skuCode,
         batchLot: transaction.batchLot,
         transactionType: transaction.transactionType,
@@ -146,6 +147,7 @@ export async function createTransactionBatch(
         await handleTransactionCosts({
           transactionId: transaction.id,
           warehouseCode: transaction.warehouseCode,
+          warehouseName: transaction.warehouseName,
           skuCode: transaction.skuCode,
           batchLot: transaction.batchLot,
           transactionType: transaction.transactionType,

--- a/apps/wms/src/services/storageCost.service.ts
+++ b/apps/wms/src/services/storageCost.service.ts
@@ -92,7 +92,7 @@ export async function recordStorageCostEntry({
   }
 
   const closingBalance = openingBalance + weeklyReceive - weeklyShip + weeklyAdjust
-  const normalizedClosingBalance = closingBalance
+  const normalizedClosingBalance = Math.max(0, closingBalance)
   const averageBalance = Math.max(0, (openingBalance + normalizedClosingBalance) / 2)
 
   const hasMovement =
@@ -208,15 +208,6 @@ export async function ensureWeeklyStorageEntries(date: Date = new Date()) {
   const errors: string[] = []
 
   for (const agg of aggregates) {
-    const closingBalance = 
-      Number(agg._sum.cartonsIn || 0) - Number(agg._sum.cartonsOut || 0)
-    
-    // Skip batches with no inventory
-    if (closingBalance <= 0) {
-      skipped++
-      continue
-    }
-
     try {
       // Check if entry already exists
       const exists = await prisma.storageLedger.findUnique({
@@ -245,6 +236,8 @@ export async function ensureWeeklyStorageEntries(date: Date = new Date()) {
           if (result.isCostCalculated) {
             costCalculated++
           }
+        } else {
+          skipped++
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- scope purchase order uniqueness by warehouse and prevent duplicate SKU/batch lines via a new migration
- require explicit order references, normalize fallback batch lots, and preserve workflow status in purchase order upserts while sharing the resolver across API, movement notes, and demo data
- recalculate storage ledger entries on every transaction to maintain weekly balances and costs

## Testing
- pnpm --filter @ecom-os/wms lint
- pnpm --filter @ecom-os/wms typecheck *(fails: pre-existing Prisma typing issues across the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a54fc65c8321b21b07616a1146ca