### PR TITLE
x-plan: redirect home to product setup sheet

### DIFF
--- a/apps/x-plan/app/page.tsx
+++ b/apps/x-plan/app/page.tsx
@@ -1,6 +1,4 @@
-import { getWorkbookStatus } from '@/lib/workbook'
-import { WorkbookLayout } from '@/components/workbook-layout'
-import { SheetTabs } from '@/components/sheet-tabs'
+import { redirect } from 'next/navigation'
 import { loadPlanningCalendar, resolveActiveYear } from '@/lib/planning'
 
 type HomePageProps = {
@@ -8,64 +6,34 @@ type HomePageProps = {
 }
 
 export default async function HomePage({ searchParams }: HomePageProps) {
-  const [status, planningCalendar, rawSearchParams] = await Promise.all([
-    getWorkbookStatus(),
+  const [planningCalendar, rawSearchParams] = await Promise.all([
     loadPlanningCalendar(),
     searchParams ?? Promise.resolve({}),
   ])
 
-  const rows = status.sheets.reduce((sum, item) => sum + item.recordCount, 0)
-  const latestUpdated = status.sheets.reduce<string | undefined>((latest, sheet) => {
-    if (!sheet.lastUpdated) return latest
-    if (!latest) return sheet.lastUpdated
-    return new Date(sheet.lastUpdated) > new Date(latest) ? sheet.lastUpdated : latest
-  }, undefined)
+  const parsedSearch = rawSearchParams as Record<string, string | string[] | undefined>
+  const activeYear = resolveActiveYear(parsedSearch.year, planningCalendar.yearSegments)
 
-  const activeYear = resolveActiveYear((rawSearchParams as Record<string, string | string[] | undefined>).year, planningCalendar.yearSegments)
+  const params = new URLSearchParams()
+  Object.entries(parsedSearch).forEach(([key, value]) => {
+    if (value == null) return
+    if (Array.isArray(value)) {
+      value.forEach((item) => {
+        if (item != null) params.append(key, String(item))
+      })
+      return
+    }
+    params.set(key, String(value))
+  })
 
-  const meta = {
-    rows,
-    updated: latestUpdated,
+  if (activeYear == null) {
+    params.delete('year')
+  } else {
+    params.set('year', String(activeYear))
   }
 
-  const buildSheetHref = (slug: string) => {
-    if (activeYear == null) return `/sheet/${slug}`
-    const params = new URLSearchParams({ year: String(activeYear) })
-    return `/sheet/${slug}?${params.toString()}`
-  }
+  const query = params.toString()
+  const href = query ? `/sheet/1-product-setup?${query}` : '/sheet/1-product-setup'
 
-  const sheetTabs = status.sheets.map((sheet) => ({ ...sheet, href: buildSheetHref(sheet.slug) }))
-
-  return (
-    <WorkbookLayout
-      sheets={status.sheets}
-      activeSlug="1-product-setup"
-      planningYears={planningCalendar.yearSegments}
-      activeYear={activeYear}
-      meta={meta}
-      ribbon={
-        <a
-          href="/import"
-          className="rounded-md border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
-        >
-          Import / Export
-        </a>
-      }
-    >
-      <div className="flex flex-col gap-3 text-sm text-slate-600 dark:text-slate-300">
-        <p>X-Plan centralizes Sales, Operations, and Finance planning in a single grid-first workspace.</p>
-        <SheetTabs
-          sheets={sheetTabs}
-          activeSlug="1-product-setup"
-          variant="scroll"
-        />
-        <a
-          href={buildSheetHref('1-product-setup')}
-          className="inline-flex w-max items-center justify-center rounded-md bg-slate-900 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-slate-700 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-200"
-        >
-          Open Product Setup
-        </a>
-      </div>
-    </WorkbookLayout>
-  )
+  redirect(href)
 }


### PR DESCRIPTION
## Summary
- redirect the X-Plan home route straight to the Product Setup sheet
- normalize search parameters while ensuring a valid planning year is forwarded

## Testing
- pnpm --filter @ecom-os/x-plan lint

------
https://chatgpt.com/codex/tasks/task_e_68dabf257de4832182ffde92ef523fd0