### PR TITLE
ui(x-plan): modernize product setup parameter panel

### DIFF
--- a/apps/x-plan/app/sheet/[sheet]/page.tsx
+++ b/apps/x-plan/app/sheet/[sheet]/page.tsx
@@ -1,8 +1,7 @@
 import { notFound } from 'next/navigation'
 import type { ReactNode } from 'react'
 import { OpsPlanningWorkspace } from '@/components/sheets/ops-planning-workspace'
-import { ProductSetupGrid } from '@/components/sheets/product-setup-grid'
-import { ProductSetupParametersPanel } from '@/components/sheets/product-setup-panels'
+import { ProductSetupWorkspace } from '@/components/sheets/product-setup-workspace'
 import { SalesPlanningGrid, SalesPlanningFocusControl, SalesPlanningFocusProvider } from '@/components/sheets/sales-planning-grid'
 import { ProfitAndLossGrid } from '@/components/sheets/fin-planning-pl-grid'
 import { CashFlowGrid } from '@/components/sheets/fin-planning-cash-grid'
@@ -1245,39 +1244,13 @@ export default async function SheetPage({ params, searchParams }: SheetPageProps
   switch (config.slug) {
     case '1-product-setup': {
       const view = await getProductSetupView()
-      const parameterSections = [
-        {
-          key: 'operations',
-          title: 'Operations',
-          description: 'Tune supply chain defaults that feed ordering and lead time models.',
-          parameters: view.operationsParameters,
-        },
-        {
-          key: 'sales',
-          title: 'Sales',
-          description: 'Set demand-planning thresholds such as stock warnings and forecast assumptions.',
-          parameters: view.salesParameters,
-        },
-        {
-          key: 'finance',
-          title: 'Finance',
-          description: 'Set the cash assumptions that flow into every financial plan.',
-          parameters: view.financeParameters,
-        },
-      ] as const
-
       content = (
-        <div className="space-y-6">
-          <ProductSetupGrid products={view.products} />
-          {parameterSections.map((section) => (
-            <ProductSetupParametersPanel
-              key={section.key}
-              title={section.title}
-              description={section.description}
-              parameters={section.parameters}
-            />
-          ))}
-        </div>
+        <ProductSetupWorkspace
+          products={view.products}
+          operationsParameters={view.operationsParameters}
+          salesParameters={view.salesParameters}
+          financeParameters={view.financeParameters}
+        />
       )
       contextPane = null
       break

--- a/apps/x-plan/components/sheets/product-setup-grid.tsx
+++ b/apps/x-plan/components/sheets/product-setup-grid.tsx
@@ -1,10 +1,12 @@
 'use client'
 
+import clsx from 'clsx'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
 interface ProductSetupGridProps {
   products: Array<{ id: string; sku: string; name: string }>
+  className?: string
 }
 
 type ProductRow = {
@@ -28,7 +30,7 @@ function normalizeProducts(products: ProductSetupGridProps['products']): Product
     .sort((a, b) => a.name.localeCompare(b.name))
 }
 
-export function ProductSetupGrid({ products }: ProductSetupGridProps) {
+export function ProductSetupGrid({ products, className }: ProductSetupGridProps) {
   const initialRows = useMemo(() => normalizeProducts(products), [products])
   const [rows, setRows] = useState<ProductRow[]>(initialRows)
   const [creatingSku, setCreatingSku] = useState('')
@@ -167,19 +169,26 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
   }
 
   return (
-    <section className="space-y-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-md dark:border-slate-800 dark:bg-slate-900">
-      <header className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+    <section
+      className={clsx(
+        'relative space-y-6 rounded-3xl border border-[#0b3a52] bg-[#041324] p-6 text-slate-100 shadow-[0_26px_55px_rgba(1,12,24,0.55)] ring-1 ring-[#0f2e45]/60',
+        'before:pointer-events-none before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_15%_20%,rgba(0,194,185,0.18),transparent_55%),radial-gradient(circle_at_85%_30%,rgba(0,194,185,0.08),transparent_60%)] before:opacity-90 before:mix-blend-screen before:content-[""]',
+        'backdrop-blur-xl',
+        className
+      )}
+    >
+      <div className="relative flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">Catalogue</p>
-          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-50">Product roster</h2>
-          <p className="text-sm text-slate-600 dark:text-slate-400">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-cyan-300/80">Catalogue</p>
+          <h2 className="text-2xl font-semibold text-white">Product roster</h2>
+          <p className="max-w-xl text-sm leading-relaxed text-slate-200/80">
             Maintain the SKUs that fuel Ops, Sales, and Finance planning. Add products once and reuse the data everywhere—no year-specific copies required.
           </p>
         </div>
         <div className="flex flex-col items-start gap-3 lg:items-end">
           {isAdding ? (
             <form
-              className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800/60"
+              className="flex w-full min-w-[260px] flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 shadow-[0_14px_35px_rgba(1,18,32,0.45)] lg:w-auto"
               onSubmit={(event) => {
                 event.preventDefault()
                 handleCreateProduct()
@@ -187,21 +196,21 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
             >
               <div className="grid gap-3 sm:grid-cols-2">
                 <label className="flex flex-col gap-1 text-left">
-                  <span className="text-xs font-medium uppercase tracking-wide text-slate-600 dark:text-slate-300">SKU</span>
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.32em] text-cyan-200/80">SKU</span>
                   <input
                     value={creatingSku}
                     onChange={(event) => setCreatingSku(event.target.value)}
                     placeholder="e.g. CS-007"
-                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100 dark:focus:ring-indigo-400"
+                    className="w-full rounded-lg border border-white/15 bg-[#061d33]/90 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-400/70"
                   />
                 </label>
                 <label className="flex flex-col gap-1 text-left">
-                  <span className="text-xs font-medium uppercase tracking-wide text-slate-600 dark:text-slate-300">Product name</span>
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.32em] text-cyan-200/80">Product name</span>
                   <input
                     value={creatingName}
                     onChange={(event) => setCreatingName(event.target.value)}
                     placeholder="Amazon Choice Sample"
-                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100 dark:focus:ring-indigo-400"
+                    className="w-full rounded-lg border border-white/15 bg-[#061d33]/90 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-400/70"
                   />
                 </label>
               </div>
@@ -210,14 +219,14 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
                   type="button"
                   onClick={handleCancelCreate}
                   disabled={isCreating}
-                  className="rounded-md border border-slate-300 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-700/60"
+                  className="rounded-lg border border-white/15 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-slate-200 transition hover:border-cyan-300/60 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   Cancel
                 </button>
                 <button
                   type="submit"
                   disabled={isCreating}
-                  className="rounded-md bg-indigo-600 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white transition enabled:hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-indigo-500 dark:enabled:hover:bg-indigo-400"
+                  className="rounded-lg bg-[#00c2b9] px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-[#002430] transition hover:bg-[#00a39e] disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   {isCreating ? 'Adding…' : 'Add product'}
                 </button>
@@ -227,27 +236,27 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
             <button
               type="button"
               onClick={() => setIsAdding(true)}
-              className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white shadow-sm transition hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+              className="inline-flex items-center rounded-lg bg-[#00c2b9] px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-[#002430] shadow-[0_12px_24px_rgba(0,194,185,0.25)] transition hover:bg-[#00a39e]"
             >
               New product
             </button>
           )}
         </div>
-      </header>
+      </div>
 
-      <div className="overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-800">
-        <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
-          <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500 dark:bg-slate-900/60 dark:text-slate-400">
+      <div className="relative overflow-hidden rounded-2xl border border-white/12 bg-white/5">
+        <table className="min-w-full divide-y divide-white/10 text-sm text-slate-100">
+          <thead className="bg-white/5 text-[11px] uppercase tracking-[0.28em] text-cyan-100/80">
             <tr>
-              <th className="px-4 py-2 text-left">SKU</th>
-              <th className="px-4 py-2 text-left">Product</th>
-              <th className="px-4 py-2 text-right">Actions</th>
+              <th className="px-4 py-3 text-left font-semibold">SKU</th>
+              <th className="px-4 py-3 text-left font-semibold">Product</th>
+              <th className="px-4 py-3 text-right font-semibold">Actions</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+          <tbody className="divide-y divide-white/8">
             {rows.length === 0 ? (
               <tr>
-                <td colSpan={3} className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+                <td colSpan={3} className="px-4 py-6 text-center text-sm text-slate-300/80">
                   No products yet. Use “New product” to add the first SKU to the planning catalogue.
                 </td>
               </tr>
@@ -257,16 +266,16 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
                 const isSaving = savingId === row.id
                 const isDeletingRow = deletingId === row.id
                 return (
-                  <tr key={row.id} className="bg-white transition hover:bg-slate-50 dark:bg-slate-900 dark:hover:bg-slate-800/50">
+                  <tr key={row.id} className="bg-white/5 transition hover:bg-white/10">
                     <td className="px-4 py-3 align-top">
                       {isEditing ? (
                         <input
                           value={editDraftSku}
                           onChange={(event) => setEditDraftSku(event.target.value)}
-                          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:focus:ring-slate-600"
+                          className="w-full rounded-lg border border-cyan-400/50 bg-[#061d33]/95 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:border-cyan-300 focus:outline-none focus:ring-2 focus:ring-cyan-300/70"
                         />
                       ) : (
-                        <span className="font-medium text-slate-700 dark:text-slate-200">{row.sku || '—'}</span>
+                        <span className="font-semibold tracking-wide text-white/90">{row.sku || '—'}</span>
                       )}
                     </td>
                     <td className="px-4 py-3 align-top">
@@ -274,10 +283,10 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
                         <input
                           value={editDraftName}
                           onChange={(event) => setEditDraftName(event.target.value)}
-                          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:focus:ring-slate-600"
+                          className="w-full rounded-lg border border-cyan-400/50 bg-[#061d33]/95 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:border-cyan-300 focus:outline-none focus:ring-2 focus:ring-cyan-300/70"
                         />
                       ) : (
-                        <span className="text-slate-700 dark:text-slate-200">{row.name || '—'}</span>
+                        <span className="text-slate-100/90">{row.name || '—'}</span>
                       )}
                     </td>
                     <td className="px-4 py-3 align-top text-right">
@@ -288,14 +297,14 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
                               type="button"
                               onClick={() => handleSaveEdit(row)}
                               disabled={isSaving}
-                              className="rounded-md bg-slate-900 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white transition enabled:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:enabled:hover:bg-slate-200"
+                              className="rounded-lg bg-[#00c2b9] px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] text-[#002430] transition enabled:hover:bg-[#00a39e] disabled:cursor-not-allowed disabled:opacity-60"
                             >
                               {isSaving ? 'Saving…' : 'Save'}
                             </button>
                             <button
                               type="button"
                               onClick={handleCancelEdit}
-                              className="rounded-md border border-slate-300 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+                              className="rounded-lg border border-white/20 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-200 transition hover:border-cyan-300/60 hover:text-white"
                             >
                               Cancel
                             </button>
@@ -305,7 +314,7 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
                             <button
                               type="button"
                               onClick={() => handleStartEdit(row)}
-                              className="rounded-md border border-slate-300 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+                              className="rounded-lg border border-white/20 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-200 transition hover:border-cyan-300/60 hover:text-white"
                             >
                               Edit
                             </button>
@@ -313,7 +322,7 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
                               type="button"
                               onClick={() => handleDelete(row)}
                               disabled={isDeletingRow}
-                              className="rounded-md border border-rose-300 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-rose-600 transition enabled:hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-rose-500/60 dark:text-rose-300 dark:enabled:hover:bg-rose-500/10"
+                              className="rounded-lg border border-rose-400/50 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] text-rose-200 transition enabled:hover:border-rose-300 enabled:hover:text-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
                             >
                               {isDeletingRow ? 'Removing…' : 'Delete'}
                             </button>

--- a/apps/x-plan/components/sheets/product-setup-grid.tsx
+++ b/apps/x-plan/components/sheets/product-setup-grid.tsx
@@ -33,6 +33,7 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
   const [rows, setRows] = useState<ProductRow[]>(initialRows)
   const [creatingSku, setCreatingSku] = useState('')
   const [creatingName, setCreatingName] = useState('')
+  const [isAdding, setIsAdding] = useState(false)
   const [isCreating, setIsCreating] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editDraftSku, setEditDraftSku] = useState('')
@@ -73,6 +74,7 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
       }
       setRows((previous) => normalizeProducts([...previous, created]))
       resetCreateForm()
+      setIsAdding(false)
       toast.success('Product added')
     } catch (error) {
       console.error(error)
@@ -80,6 +82,12 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
     } finally {
       setIsCreating(false)
     }
+  }
+
+  const handleCancelCreate = () => {
+    if (isCreating) return
+    resetCreateForm()
+    setIsAdding(false)
   }
 
   const handleStartEdit = (row: ProductRow) => {
@@ -159,54 +167,72 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
   }
 
   return (
-    <section className="space-y-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <header className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+    <section className="space-y-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-md dark:border-slate-800 dark:bg-slate-900">
+      <header className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-wide text-teal-600 dark:text-teal-300">Catalogue</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">Catalogue</p>
           <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-50">Product roster</h2>
-          <p className="text-sm text-slate-500 dark:text-slate-400">
+          <p className="text-sm text-slate-600 dark:text-slate-400">
             Maintain the SKUs that fuel Ops, Sales, and Finance planning. Add products once and reuse the data everywhere—no year-specific copies required.
           </p>
         </div>
-        <form
-          className="flex w-full flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 sm:flex-row sm:items-center sm:border-transparent sm:bg-transparent sm:p-0 lg:w-auto"
-          onSubmit={(event) => {
-            event.preventDefault()
-            handleCreateProduct()
-          }}
-        >
-          <div className="flex flex-col gap-1">
-            <label htmlFor="new-sku" className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              SKU
-            </label>
-            <input
-              id="new-sku"
-              value={creatingSku}
-              onChange={(event) => setCreatingSku(event.target.value)}
-              placeholder="e.g. CS-007"
-              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:focus:ring-slate-600"
-            />
-          </div>
-          <div className="flex flex-col gap-1">
-            <label htmlFor="new-name" className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              Product name
-            </label>
-            <input
-              id="new-name"
-              value={creatingName}
-              onChange={(event) => setCreatingName(event.target.value)}
-              placeholder="Amazon Choice Sample"
-              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:focus:ring-slate-600"
-            />
-          </div>
-          <button
-            type="submit"
-            disabled={isCreating}
-            className="rounded-md bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white transition enabled:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:enabled:hover:bg-slate-200"
-          >
-            {isCreating ? 'Adding…' : 'Add product'}
-          </button>
-        </form>
+        <div className="flex flex-col items-start gap-3 lg:items-end">
+          {isAdding ? (
+            <form
+              className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800/60"
+              onSubmit={(event) => {
+                event.preventDefault()
+                handleCreateProduct()
+              }}
+            >
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label className="flex flex-col gap-1 text-left">
+                  <span className="text-xs font-medium uppercase tracking-wide text-slate-600 dark:text-slate-300">SKU</span>
+                  <input
+                    value={creatingSku}
+                    onChange={(event) => setCreatingSku(event.target.value)}
+                    placeholder="e.g. CS-007"
+                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100 dark:focus:ring-indigo-400"
+                  />
+                </label>
+                <label className="flex flex-col gap-1 text-left">
+                  <span className="text-xs font-medium uppercase tracking-wide text-slate-600 dark:text-slate-300">Product name</span>
+                  <input
+                    value={creatingName}
+                    onChange={(event) => setCreatingName(event.target.value)}
+                    placeholder="Amazon Choice Sample"
+                    className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100 dark:focus:ring-indigo-400"
+                  />
+                </label>
+              </div>
+              <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                <button
+                  type="button"
+                  onClick={handleCancelCreate}
+                  disabled={isCreating}
+                  className="rounded-md border border-slate-300 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-700/60"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={isCreating}
+                  className="rounded-md bg-indigo-600 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white transition enabled:hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-indigo-500 dark:enabled:hover:bg-indigo-400"
+                >
+                  {isCreating ? 'Adding…' : 'Add product'}
+                </button>
+              </div>
+            </form>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setIsAdding(true)}
+              className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white shadow-sm transition hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+            >
+              New product
+            </button>
+          )}
+        </div>
       </header>
 
       <div className="overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-800">
@@ -222,7 +248,7 @@ export function ProductSetupGrid({ products }: ProductSetupGridProps) {
             {rows.length === 0 ? (
               <tr>
                 <td colSpan={3} className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
-                  No products yet. Add your first SKU above to populate the planning catalogue.
+                  No products yet. Use “New product” to add the first SKU to the planning catalogue.
                 </td>
               </tr>
             ) : (

--- a/apps/x-plan/components/sheets/product-setup-panels.tsx
+++ b/apps/x-plan/components/sheets/product-setup-panels.tsx
@@ -42,11 +42,19 @@ function formatNumericForDisplay(value: string): string {
 
 export function ProductSetupParametersPanel({ title, description, parameters }: ProductSetupParametersPanelProps) {
   const flushTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const isFlushingRef = useRef(false)
+  const pendingFlushRef = useRef(false)
   const [items, setItems] = useState<ParameterRecord[]>(() => initializeRecords(parameters))
   const itemsRef = useRef(items)
 
   useEffect(() => {
-    setItems(initializeRecords(parameters))
+    const nextRecords = initializeRecords(parameters)
+    if (flushTimeoutRef.current) {
+      clearTimeout(flushTimeoutRef.current)
+      flushTimeoutRef.current = null
+    }
+    setItems(nextRecords)
+    itemsRef.current = nextRecords
   }, [parameters])
 
   useEffect(() => {
@@ -60,6 +68,13 @@ export function ProductSetupParametersPanel({ title, description, parameters }: 
       flushTimeoutRef.current = null
       return
     }
+
+    if (isFlushingRef.current) {
+      pendingFlushRef.current = true
+      return
+    }
+
+    isFlushingRef.current = true
 
     const sanitizedValues = new Map<string, string>()
     const validItems: ParameterRecord[] = []
@@ -90,6 +105,7 @@ export function ProductSetupParametersPanel({ title, description, parameters }: 
 
     if (validItems.length === 0) {
       flushTimeoutRef.current = null
+      isFlushingRef.current = false
       return
     }
 
@@ -143,6 +159,11 @@ export function ProductSetupParametersPanel({ title, description, parameters }: 
       toast.error('Unable to update parameters')
     } finally {
       flushTimeoutRef.current = null
+      isFlushingRef.current = false
+      if (pendingFlushRef.current) {
+        pendingFlushRef.current = false
+        void flushUpdates()
+      }
     }
   }, [])
 
@@ -187,49 +208,83 @@ export function ProductSetupParametersPanel({ title, description, parameters }: 
         const isError = item.status === 'error'
         const isSaving = item.status === 'saving'
         const isDirty = item.status === 'dirty'
-        let statusLabel: string | null = null
-        let statusClass = ''
-        if (isSaving) {
-          statusLabel = 'Saving…'
-          statusClass = 'text-amber-600 dark:text-amber-400'
-        } else if (isDirty) {
-          statusLabel = 'Pending save'
-          statusClass = 'text-slate-400 dark:text-slate-500'
-        } else if (isError) {
-          statusLabel = 'Save failed'
-          statusClass = 'text-rose-600 dark:text-rose-400'
-        }
-
-        const baseInputClasses =
-          'w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-75'
-        const lightThemeBorder = isError ? 'border-rose-300 focus:ring-rose-400' : 'border-slate-300 focus:ring-slate-400'
-        const darkThemeBorder = isError
-          ? 'dark:border-rose-500 dark:bg-rose-500/10 dark:text-rose-100 dark:focus:ring-rose-500'
-          : 'dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:focus:ring-slate-600'
+        const statusLabel = isSaving ? 'Saving…' : isError ? 'Save failed' : isDirty ? 'Pending save' : 'Saved'
+        const statusTone = isSaving
+          ? 'bg-amber-100 text-amber-800 dark:bg-amber-500/10 dark:text-amber-200'
+          : isError
+          ? 'bg-rose-100 text-rose-700 dark:bg-rose-500/10 dark:text-rose-200'
+          : isDirty
+          ? 'bg-slate-100 text-slate-600 dark:bg-slate-500/10 dark:text-slate-200'
+          : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-200'
+        const helperId = `${item.id}-helper`
 
         return (
           <div
             key={item.id}
-            className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-slate-300 hover:shadow-md dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-700"
+            className="border-t border-slate-200 first:border-t-0 dark:border-slate-800"
           >
-            <div className="flex flex-col gap-1">
-              <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">{item.label}</p>
-              <p className="text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">
-                {item.type === 'numeric' ? 'Numeric value (auto-formatted to 2 decimals)' : 'Text value'}
-              </p>
-            </div>
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <input
-                value={item.value}
-                onChange={(event) => handleValueChange(item.id, event.target.value)}
-                onBlur={handleBlur}
-                inputMode={item.type === 'numeric' ? 'decimal' : 'text'}
-                disabled={isSaving}
-                className={`${baseInputClasses} ${lightThemeBorder} ${darkThemeBorder}`}
-              />
-              {statusLabel ? (
-                <span className={`text-xs font-medium ${statusClass}`}>{statusLabel}</span>
-              ) : null}
+            <div className="flex flex-col gap-3 px-4 py-3 md:grid md:grid-cols-[minmax(0,2fr)_minmax(0,1.5fr)_minmax(0,1fr)] md:items-center md:gap-6">
+              <div className="flex flex-col gap-1">
+                <p className="text-sm font-medium text-slate-900 dark:text-slate-100">{item.label}</p>
+                <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                  <span className="rounded-full border border-slate-200 px-2 py-0.5 font-medium uppercase tracking-wide dark:border-slate-700">
+                    {item.type === 'numeric' ? 'Numeric' : 'Text'}
+                  </span>
+                  <span id={helperId} className="hidden md:inline">
+                    {item.type === 'numeric'
+                      ? 'Auto-formats to two decimal places after saving.'
+                      : 'Saved exactly as typed.'}
+                  </span>
+                </div>
+              </div>
+              <div className="flex flex-col gap-1">
+                <input
+                  value={item.value}
+                  onChange={(event) => handleValueChange(item.id, event.target.value)}
+                  onBlur={handleBlur}
+                  inputMode={item.type === 'numeric' ? 'decimal' : 'text'}
+                  aria-describedby={helperId}
+                  aria-invalid={isError}
+                  disabled={isSaving}
+                  className={`w-full rounded-lg border px-3 py-2 text-sm shadow-sm transition focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-70 ${
+                    isError
+                      ? 'border-rose-300 text-rose-900 focus:ring-rose-500 dark:border-rose-500 dark:bg-rose-500/10 dark:text-rose-100 dark:focus:ring-rose-400'
+                      : 'border-slate-200 focus:ring-teal-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:ring-teal-400'
+                  }`}
+                />
+                {isError ? (
+                  <p className="text-xs font-medium text-rose-600 dark:text-rose-300">Check the value and try saving again.</p>
+                ) : null}
+              </div>
+              <div className="flex items-center justify-between gap-3 md:justify-end">
+                <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${statusTone}`}>
+                  {statusLabel}
+                </span>
+                {isSaving ? (
+                  <svg
+                    className="h-4 w-4 animate-spin text-amber-500"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      d="M4 12a8 8 0 018-8"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                ) : null}
+              </div>
             </div>
           </div>
         )
@@ -239,11 +294,18 @@ export function ProductSetupParametersPanel({ title, description, parameters }: 
 
   return (
     <section className="space-y-4 rounded-3xl border border-slate-200 bg-slate-50 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/60">
-      <header className="space-y-2">
+      <header className="space-y-1">
         <p className="text-xs font-semibold uppercase tracking-wide text-teal-600 dark:text-teal-300">{title}</p>
         <p className="text-sm text-slate-600 dark:text-slate-400">{description}</p>
       </header>
-      <div className="grid gap-4 md:grid-cols-2">{sections}</div>
+      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950">
+        <div className="hidden border-b border-slate-200 bg-slate-100 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-300 md:grid md:grid-cols-[minmax(0,2fr)_minmax(0,1.5fr)_minmax(0,1fr)]">
+          <span>Parameter</span>
+          <span>Value</span>
+          <span>Status</span>
+        </div>
+        <div>{sections}</div>
+      </div>
     </section>
   )
 }

--- a/apps/x-plan/components/sheets/product-setup-panels.tsx
+++ b/apps/x-plan/components/sheets/product-setup-panels.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import clsx from 'clsx'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -16,6 +17,7 @@ export interface ProductSetupParametersPanelProps {
   title: string
   description: string
   parameters: BusinessParameter[]
+  className?: string
 }
 
 type ParameterStatus = 'idle' | 'dirty' | 'saving' | 'error'
@@ -40,7 +42,12 @@ function formatNumericForDisplay(value: string): string {
   return normalized.toFixed(2)
 }
 
-export function ProductSetupParametersPanel({ title, description, parameters }: ProductSetupParametersPanelProps) {
+export function ProductSetupParametersPanel({
+  title,
+  description,
+  parameters,
+  className,
+}: ProductSetupParametersPanelProps) {
   const flushTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const isFlushingRef = useRef(false)
   const pendingFlushRef = useRef(false)
@@ -202,103 +209,108 @@ export function ProductSetupParametersPanel({ title, description, parameters }: 
     void flushUpdates()
   }, [flushUpdates])
 
-  const sections = useMemo(
-    () =>
-      items.map((item) => {
-        const isError = item.status === 'error'
-        const isSaving = item.status === 'saving'
-        const isDirty = item.status === 'dirty'
-        const statusLabel = isSaving ? 'Saving…' : isError ? 'Save failed' : isDirty ? 'Pending save' : 'Saved'
-        const statusTone = isSaving
-          ? 'bg-amber-50 text-amber-700 ring-1 ring-amber-200 dark:bg-amber-500/15 dark:text-amber-200'
-          : isError
-          ? 'bg-rose-50 text-rose-700 ring-1 ring-rose-200 dark:bg-rose-500/15 dark:text-rose-200'
-          : isDirty
-          ? 'bg-slate-200 text-slate-700 ring-1 ring-slate-300 dark:bg-slate-500/20 dark:text-slate-200'
-          : 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200 dark:bg-emerald-500/15 dark:text-emerald-200'
+  const parameterCards = useMemo(() => {
+    return items.map((item) => {
+      const isError = item.status === 'error'
+      const isSaving = item.status === 'saving'
+      const isDirty = item.status === 'dirty'
+      const statusLabel = isSaving ? 'Saving…' : isError ? 'Save failed' : isDirty ? 'Pending save' : 'Saved'
 
-        return (
-          <div
-            key={item.id}
-            className="border-t border-slate-200 first:border-t-0 dark:border-slate-800"
-          >
-            <div className="flex flex-col gap-3 px-4 py-3 md:grid md:grid-cols-[minmax(0,2fr)_minmax(0,1.5fr)_minmax(0,1fr)] md:items-center md:gap-6">
-              <div className="flex flex-col gap-1">
-                <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{item.label}</p>
-                <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
-                  <span className="rounded-full bg-slate-200 px-2 py-0.5 font-semibold uppercase tracking-wide text-slate-700 dark:bg-slate-700 dark:text-slate-200">
-                    {item.type === 'numeric' ? 'Numeric' : 'Text'}
-                  </span>
-                </div>
-              </div>
-              <div className="flex flex-col gap-1">
-                <input
-                  value={item.value}
-                  onChange={(event) => handleValueChange(item.id, event.target.value)}
-                  onBlur={handleBlur}
-                  inputMode={item.type === 'numeric' ? 'decimal' : 'text'}
-                  aria-invalid={isError}
-                  disabled={isSaving}
-                  className={`w-full rounded-lg border px-3 py-2 text-sm shadow-sm transition focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-70 ${
-                    isError
-                      ? 'border-rose-400 text-rose-900 focus:ring-rose-500 dark:border-rose-500 dark:bg-rose-500/10 dark:text-rose-100 dark:focus:ring-rose-400'
-                      : 'border-slate-300 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:ring-indigo-400'
-                  }`}
-                />
-                {isError ? (
-                  <p className="text-xs font-medium text-rose-600 dark:text-rose-300">Check the value and try saving again.</p>
-                ) : null}
-              </div>
-              <div className="flex items-center justify-between gap-3 md:justify-end">
-                <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${statusTone}`}>
-                  {statusLabel}
-                </span>
-                {isSaving ? (
-                  <svg
-                    className="h-4 w-4 animate-spin text-amber-500"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    />
-                    <path
-                      className="opacity-75"
-                      d="M4 12a8 8 0 018-8"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                      strokeLinecap="round"
-                    />
-                  </svg>
-                ) : null}
-              </div>
+      const statusTone = clsx(
+        'inline-flex items-center gap-1 rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em]',
+        isSaving
+          ? 'border-amber-400/40 bg-amber-300/20 text-amber-100'
+          : isError
+          ? 'border-rose-400/40 bg-rose-400/15 text-rose-100'
+          : isDirty
+          ? 'border-cyan-400/40 bg-cyan-400/15 text-cyan-100'
+          : 'border-emerald-400/40 bg-emerald-400/10 text-emerald-100'
+      )
+
+      return (
+        <div
+          key={item.id}
+          className={clsx(
+            'group relative flex flex-col gap-3 rounded-2xl border border-white/12 bg-[#06182b]/85 p-4 text-slate-100 shadow-[0_16px_40px_rgba(1,12,24,0.45)] transition',
+            'ring-1 ring-transparent hover:ring-cyan-400/40'
+          )}
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1">
+              <p className="text-sm font-semibold leading-snug text-white/90">{item.label}</p>
+              <span className="inline-flex rounded-full border border-white/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.34em] text-cyan-200/80">
+                {item.type === 'numeric' ? 'Numeric' : 'Text'}
+              </span>
             </div>
+            <span className={statusTone}>{statusLabel}</span>
           </div>
-        )
-      }),
-    [handleBlur, handleValueChange, items]
-  )
+          <div className="flex items-center gap-3">
+            <div className="flex-1">
+              <input
+                value={item.value}
+                onChange={(event) => handleValueChange(item.id, event.target.value)}
+                onBlur={handleBlur}
+                inputMode={item.type === 'numeric' ? 'decimal' : 'text'}
+                aria-invalid={isError}
+                aria-describedby={isError ? `${item.id}-error` : undefined}
+                disabled={isSaving}
+                className={clsx(
+                  'w-full rounded-xl border px-3 py-2 text-sm font-medium tracking-wide transition focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-70',
+                  isError
+                    ? 'border-rose-400/60 bg-rose-500/10 text-rose-50 focus:border-rose-300 focus:ring-rose-300/60'
+                    : 'border-white/15 bg-[#031222]/80 text-slate-100 placeholder-slate-500 focus:border-cyan-300 focus:ring-cyan-300/60'
+                )}
+              />
+              {isError ? (
+                <p id={`${item.id}-error`} className="mt-1 text-[11px] font-medium text-rose-200">
+                  Check the value and try saving again.
+                </p>
+              ) : null}
+            </div>
+            {isSaving ? (
+              <svg
+                className="h-5 w-5 animate-spin text-cyan-200/80"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  d="M4 12a8 8 0 018-8"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                  strokeLinecap="round"
+                />
+              </svg>
+            ) : null}
+          </div>
+        </div>
+      )
+    })
+  }, [handleBlur, handleValueChange, items])
 
   return (
-    <section className="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-md dark:border-slate-800 dark:bg-slate-900">
-      <header className="space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">{title}</p>
-        <p className="text-sm text-slate-600 dark:text-slate-400">{description}</p>
-      </header>
-      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-slate-50 shadow-sm dark:border-slate-800 dark:bg-slate-900/40">
-        <div className="hidden border-b border-slate-200 bg-slate-100 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-600 dark:border-slate-800 dark:bg-slate-800/60 dark:text-slate-300 md:grid md:grid-cols-[minmax(0,2fr)_minmax(0,1.5fr)_minmax(0,1fr)]">
-          <span>Parameter</span>
-          <span>Value</span>
-          <span>Status</span>
-        </div>
-        <div>{sections}</div>
+    <section
+      className={clsx(
+        'relative space-y-4 rounded-3xl border border-[#0b3a52] bg-[#041324] p-6 text-slate-100 shadow-[0_26px_55px_rgba(1,12,24,0.55)] ring-1 ring-[#0f2e45]/60',
+        'before:pointer-events-none before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_10%_18%,rgba(0,194,185,0.16),transparent_60%),radial-gradient(circle_at_90%_25%,rgba(0,194,185,0.1),transparent_65%)] before:opacity-90 before:mix-blend-screen before:content-[""]',
+        'backdrop-blur-xl',
+        className
+      )}
+    >
+      <div className="relative space-y-2">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-cyan-300/80">{title}</p>
+        <p className="max-w-xl text-sm leading-relaxed text-slate-200/80">{description}</p>
       </div>
+      <div className="relative grid gap-3 md:grid-cols-2 xl:grid-cols-3">{parameterCards}</div>
     </section>
   )
 }

--- a/apps/x-plan/components/sheets/product-setup-panels.tsx
+++ b/apps/x-plan/components/sheets/product-setup-panels.tsx
@@ -210,13 +210,12 @@ export function ProductSetupParametersPanel({ title, description, parameters }: 
         const isDirty = item.status === 'dirty'
         const statusLabel = isSaving ? 'Saving…' : isError ? 'Save failed' : isDirty ? 'Pending save' : 'Saved'
         const statusTone = isSaving
-          ? 'bg-amber-100 text-amber-800 dark:bg-amber-500/10 dark:text-amber-200'
+          ? 'bg-amber-50 text-amber-700 ring-1 ring-amber-200 dark:bg-amber-500/15 dark:text-amber-200'
           : isError
-          ? 'bg-rose-100 text-rose-700 dark:bg-rose-500/10 dark:text-rose-200'
+          ? 'bg-rose-50 text-rose-700 ring-1 ring-rose-200 dark:bg-rose-500/15 dark:text-rose-200'
           : isDirty
-          ? 'bg-slate-100 text-slate-600 dark:bg-slate-500/10 dark:text-slate-200'
-          : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-200'
-        const helperId = `${item.id}-helper`
+          ? 'bg-slate-200 text-slate-700 ring-1 ring-slate-300 dark:bg-slate-500/20 dark:text-slate-200'
+          : 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200 dark:bg-emerald-500/15 dark:text-emerald-200'
 
         return (
           <div
@@ -225,15 +224,10 @@ export function ProductSetupParametersPanel({ title, description, parameters }: 
           >
             <div className="flex flex-col gap-3 px-4 py-3 md:grid md:grid-cols-[minmax(0,2fr)_minmax(0,1.5fr)_minmax(0,1fr)] md:items-center md:gap-6">
               <div className="flex flex-col gap-1">
-                <p className="text-sm font-medium text-slate-900 dark:text-slate-100">{item.label}</p>
+                <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{item.label}</p>
                 <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
-                  <span className="rounded-full border border-slate-200 px-2 py-0.5 font-medium uppercase tracking-wide dark:border-slate-700">
+                  <span className="rounded-full bg-slate-200 px-2 py-0.5 font-semibold uppercase tracking-wide text-slate-700 dark:bg-slate-700 dark:text-slate-200">
                     {item.type === 'numeric' ? 'Numeric' : 'Text'}
-                  </span>
-                  <span id={helperId} className="hidden md:inline">
-                    {item.type === 'numeric'
-                      ? 'Auto-formats to two decimal places after saving.'
-                      : 'Saved exactly as typed.'}
                   </span>
                 </div>
               </div>
@@ -243,13 +237,12 @@ export function ProductSetupParametersPanel({ title, description, parameters }: 
                   onChange={(event) => handleValueChange(item.id, event.target.value)}
                   onBlur={handleBlur}
                   inputMode={item.type === 'numeric' ? 'decimal' : 'text'}
-                  aria-describedby={helperId}
                   aria-invalid={isError}
                   disabled={isSaving}
                   className={`w-full rounded-lg border px-3 py-2 text-sm shadow-sm transition focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-70 ${
                     isError
-                      ? 'border-rose-300 text-rose-900 focus:ring-rose-500 dark:border-rose-500 dark:bg-rose-500/10 dark:text-rose-100 dark:focus:ring-rose-400'
-                      : 'border-slate-200 focus:ring-teal-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:ring-teal-400'
+                      ? 'border-rose-400 text-rose-900 focus:ring-rose-500 dark:border-rose-500 dark:bg-rose-500/10 dark:text-rose-100 dark:focus:ring-rose-400'
+                      : 'border-slate-300 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:ring-indigo-400'
                   }`}
                 />
                 {isError ? (
@@ -293,13 +286,13 @@ export function ProductSetupParametersPanel({ title, description, parameters }: 
   )
 
   return (
-    <section className="space-y-4 rounded-3xl border border-slate-200 bg-slate-50 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/60">
+    <section className="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-md dark:border-slate-800 dark:bg-slate-900">
       <header className="space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-wide text-teal-600 dark:text-teal-300">{title}</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">{title}</p>
         <p className="text-sm text-slate-600 dark:text-slate-400">{description}</p>
       </header>
-      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950">
-        <div className="hidden border-b border-slate-200 bg-slate-100 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-300 md:grid md:grid-cols-[minmax(0,2fr)_minmax(0,1.5fr)_minmax(0,1fr)]">
+      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-slate-50 shadow-sm dark:border-slate-800 dark:bg-slate-900/40">
+        <div className="hidden border-b border-slate-200 bg-slate-100 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-600 dark:border-slate-800 dark:bg-slate-800/60 dark:text-slate-300 md:grid md:grid-cols-[minmax(0,2fr)_minmax(0,1.5fr)_minmax(0,1fr)]">
           <span>Parameter</span>
           <span>Value</span>
           <span>Status</span>

--- a/apps/x-plan/components/sheets/product-setup-panels.tsx
+++ b/apps/x-plan/components/sheets/product-setup-panels.tsx
@@ -1,14 +1,7 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { HotTable } from '@handsontable/react'
-import Handsontable from 'handsontable'
-import { registerAllModules } from 'handsontable/registry'
-import 'handsontable/dist/handsontable.full.min.css'
-import '@/styles/handsontable-theme.css'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
-
-registerAllModules()
 
 interface BusinessParameter {
   id: string
@@ -25,160 +18,232 @@ export interface ProductSetupParametersPanelProps {
   parameters: BusinessParameter[]
 }
 
-function toCellValue(value: unknown) {
-  if (value === null || value === undefined) return ''
-  return String(value)
+type ParameterStatus = 'idle' | 'dirty' | 'saving' | 'error'
+
+interface ParameterRecord extends BusinessParameter {
+  status: ParameterStatus
+}
+
+function initializeRecords(parameters: BusinessParameter[]): ParameterRecord[] {
+  return parameters.map((parameter) => ({
+    ...parameter,
+    value: parameter.value ?? '',
+    status: 'idle' as ParameterStatus,
+  }))
+}
+
+function formatNumericForDisplay(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) return ''
+  const normalized = Number(trimmed.replace(/,/g, ''))
+  if (Number.isNaN(normalized)) return value
+  return normalized.toFixed(2)
 }
 
 export function ProductSetupParametersPanel({ title, description, parameters }: ProductSetupParametersPanelProps) {
-  const hotRef = useRef<Handsontable | null>(null)
-  const pendingRef = useRef<Map<string, string>>(new Map())
   const flushTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const [isClient, setIsClient] = useState(false)
-
-  const data = useMemo<BusinessParameter[]>(() => parameters.map((parameter) => ({ ...parameter })), [parameters])
+  const [items, setItems] = useState<ParameterRecord[]>(() => initializeRecords(parameters))
+  const itemsRef = useRef(items)
 
   useEffect(() => {
-    if (hotRef.current) {
-      hotRef.current.loadData(data)
+    setItems(initializeRecords(parameters))
+  }, [parameters])
+
+  useEffect(() => {
+    itemsRef.current = items
+  }, [items])
+
+  const flushUpdates = useCallback(async () => {
+    const currentItems = itemsRef.current
+    const dirtyItems = currentItems.filter((item) => item.status === 'dirty')
+    if (dirtyItems.length === 0) {
+      flushTimeoutRef.current = null
+      return
     }
-    pendingRef.current.clear()
-    if (flushTimeoutRef.current) {
-      clearTimeout(flushTimeoutRef.current)
+
+    const sanitizedValues = new Map<string, string>()
+    const validItems: ParameterRecord[] = []
+    const invalidIds = new Set<string>()
+
+    dirtyItems.forEach((item) => {
+      const trimmed = item.value.trim()
+      if (item.type === 'numeric') {
+        const cleaned = trimmed.replace(/,/g, '')
+        if (cleaned !== '' && Number.isNaN(Number(cleaned))) {
+          invalidIds.add(item.id)
+          return
+        }
+        sanitizedValues.set(item.id, cleaned)
+        validItems.push(item)
+      } else {
+        sanitizedValues.set(item.id, trimmed)
+        validItems.push(item)
+      }
+    })
+
+    if (invalidIds.size > 0) {
+      setItems((previous) =>
+        previous.map((item) => (invalidIds.has(item.id) ? { ...item, status: 'error' } : item))
+      )
+      toast.error('Enter a valid numeric value to continue')
+    }
+
+    if (validItems.length === 0) {
+      flushTimeoutRef.current = null
+      return
+    }
+
+    const dirtyIds = new Set(validItems.map((item) => item.id))
+
+    setItems((previous) =>
+      previous.map((item) => (dirtyIds.has(item.id) ? { ...item, status: 'saving' } : item))
+    )
+
+    const payload: BusinessParameterUpdate[] = validItems.map((item) => {
+      const sanitized = sanitizedValues.get(item.id) ?? ''
+      if (item.type === 'numeric') {
+        return { id: item.id, valueNumeric: sanitized }
+      }
+      return { id: item.id, valueText: sanitized }
+    })
+
+    try {
+      const response = await fetch('/api/v1/x-plan/business-parameters', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ updates: payload }),
+      })
+      if (!response.ok) throw new Error('Failed to update parameters')
+
+      setItems((previous) =>
+        previous.map((item) => {
+          if (!dirtyIds.has(item.id)) return item
+          const sanitized = sanitizedValues.get(item.id) ?? ''
+          if (item.type === 'numeric') {
+            return {
+              ...item,
+              value: formatNumericForDisplay(sanitized),
+              status: 'idle',
+            }
+          }
+          return {
+            ...item,
+            value: sanitized,
+            status: 'idle',
+          }
+        })
+      )
+
+      toast.success('Parameters updated')
+    } catch (error) {
+      console.error(error)
+      setItems((previous) =>
+        previous.map((item) => (dirtyIds.has(item.id) ? { ...item, status: 'error' } : item))
+      )
+      toast.error('Unable to update parameters')
+    } finally {
       flushTimeoutRef.current = null
     }
-  }, [data])
+  }, [])
+
+  const scheduleFlush = useCallback(() => {
+    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current)
+    flushTimeoutRef.current = setTimeout(() => {
+      void flushUpdates()
+    }, 500)
+  }, [flushUpdates])
 
   useEffect(() => {
     return () => {
       if (flushTimeoutRef.current) {
         clearTimeout(flushTimeoutRef.current)
+        flushTimeoutRef.current = null
       }
+      void flushUpdates()
     }
-  }, [])
+  }, [flushUpdates])
 
-  useEffect(() => {
-    setIsClient(true)
-  }, [])
+  const handleValueChange = useCallback(
+    (id: string, value: string) => {
+      setItems((previous) =>
+        previous.map((item) => (item.id === id ? { ...item, value, status: 'dirty' } : item))
+      )
+      scheduleFlush()
+    },
+    [scheduleFlush]
+  )
 
-  const queueFlush = () => {
-    if (flushTimeoutRef.current) clearTimeout(flushTimeoutRef.current)
-    flushTimeoutRef.current = setTimeout(async () => {
-      const hot = hotRef.current
-      const rows = hot?.getSourceData() as BusinessParameter[] | undefined
-      const payload: BusinessParameterUpdate[] = []
+  const handleBlur = useCallback(() => {
+    if (flushTimeoutRef.current) {
+      clearTimeout(flushTimeoutRef.current)
+      flushTimeoutRef.current = null
+    }
+    void flushUpdates()
+  }, [flushUpdates])
 
-      for (const [id, value] of pendingRef.current.entries()) {
-        const row = rows?.find((item) => item.id === id)
-        if (!row) continue
-        if (row.type === 'numeric') {
-          payload.push({ id, valueNumeric: value })
-        } else {
-          payload.push({ id, valueText: value })
-        }
-      }
-
-      if (payload.length === 0) {
-        pendingRef.current.clear()
-        flushTimeoutRef.current = null
-        return
-      }
-
-      pendingRef.current.clear()
-
-      try {
-        const response = await fetch('/api/v1/x-plan/business-parameters', {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ updates: payload }),
-        })
-        if (!response.ok) throw new Error('Failed to update parameters')
-
-        if (hot && rows) {
-          payload.forEach((update) => {
-            if (!('valueNumeric' in update)) return
-            const rowIndex = rows.findIndex((row) => row.id === update.id)
-            if (rowIndex === -1) return
-            const numericValue = Number(update.valueNumeric)
-            if (Number.isNaN(numericValue)) return
-            const formatted = numericValue.toFixed(2)
-            rows[rowIndex].value = formatted
-            hot.setDataAtRowProp(rowIndex, 'value', formatted, 'normalize-update')
-          })
+  const sections = useMemo(
+    () =>
+      items.map((item) => {
+        const isError = item.status === 'error'
+        const isSaving = item.status === 'saving'
+        const isDirty = item.status === 'dirty'
+        let statusLabel: string | null = null
+        let statusClass = ''
+        if (isSaving) {
+          statusLabel = 'Saving…'
+          statusClass = 'text-amber-600 dark:text-amber-400'
+        } else if (isDirty) {
+          statusLabel = 'Pending save'
+          statusClass = 'text-slate-400 dark:text-slate-500'
+        } else if (isError) {
+          statusLabel = 'Save failed'
+          statusClass = 'text-rose-600 dark:text-rose-400'
         }
 
-        toast.success('Parameters updated')
-      } catch (error) {
-        console.error(error)
-        toast.error('Unable to update parameters')
-      } finally {
-        flushTimeoutRef.current = null
-      }
-    }, 400)
-  }
+        const baseInputClasses =
+          'w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-75'
+        const lightThemeBorder = isError ? 'border-rose-300 focus:ring-rose-400' : 'border-slate-300 focus:ring-slate-400'
+        const darkThemeBorder = isError
+          ? 'dark:border-rose-500 dark:bg-rose-500/10 dark:text-rose-100 dark:focus:ring-rose-500'
+          : 'dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:focus:ring-slate-600'
 
-  if (!isClient) return null
+        return (
+          <div
+            key={item.id}
+            className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-slate-300 hover:shadow-md dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-700"
+          >
+            <div className="flex flex-col gap-1">
+              <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">{item.label}</p>
+              <p className="text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">
+                {item.type === 'numeric' ? 'Numeric value (auto-formatted to 2 decimals)' : 'Text value'}
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <input
+                value={item.value}
+                onChange={(event) => handleValueChange(item.id, event.target.value)}
+                onBlur={handleBlur}
+                inputMode={item.type === 'numeric' ? 'decimal' : 'text'}
+                disabled={isSaving}
+                className={`${baseInputClasses} ${lightThemeBorder} ${darkThemeBorder}`}
+              />
+              {statusLabel ? (
+                <span className={`text-xs font-medium ${statusClass}`}>{statusLabel}</span>
+              ) : null}
+            </div>
+          </div>
+        )
+      }),
+    [handleBlur, handleValueChange, items]
+  )
 
   return (
-    <section className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <section className="space-y-4 rounded-3xl border border-slate-200 bg-slate-50 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/60">
       <header className="space-y-2">
         <p className="text-xs font-semibold uppercase tracking-wide text-teal-600 dark:text-teal-300">{title}</p>
-        <p className="text-sm text-slate-500 dark:text-slate-400">{description}</p>
+        <p className="text-sm text-slate-600 dark:text-slate-400">{description}</p>
       </header>
-      <HotTable
-        ref={(instance) => {
-          hotRef.current = instance?.hotInstance ?? null
-        }}
-        data={data}
-        licenseKey="non-commercial-and-evaluation"
-        colHeaders={['Parameter', 'Value']}
-        columns={[
-          { data: 'label', readOnly: true, className: 'cell-readonly htLeft' },
-          { data: 'value', className: 'cell-editable' },
-        ]}
-        rowHeaders={false}
-        height="auto"
-        stretchH="all"
-        className="x-plan-hot"
-        dropdownMenu
-        filters
-        afterGetColHeader={(col, TH) => {
-          if (col === 0) TH.classList.add('htLeft')
-        }}
-        cells={(row, col) => {
-          const cellProperties = {} as Handsontable.CellProperties
-          if (col === 1) {
-            const record = data[row]
-            if (record?.type === 'numeric') {
-              cellProperties.type = 'numeric'
-              cellProperties.numericFormat = { pattern: '0,0.00' }
-              cellProperties.className = 'cell-editable htRight'
-            } else {
-              cellProperties.className = 'cell-editable htLeft'
-            }
-          } else {
-            cellProperties.className = 'cell-readonly htLeft'
-          }
-          return cellProperties
-        }}
-        afterChange={(changes, source) => {
-          const changeSource = String(source)
-          if (!changes || changeSource === 'loadData' || changeSource === 'normalize-update') return
-          const hot = hotRef.current
-          if (!hot) return
-          const rows = hot.getSourceData() as BusinessParameter[]
-          for (const change of changes) {
-            const [rowIndex, prop, _oldValue, newValue] = change as [number, keyof BusinessParameter, any, any]
-            if (prop !== 'value') continue
-            const row = rows[rowIndex]
-            if (!row) continue
-            const value = toCellValue(newValue)
-            row.value = value
-            pendingRef.current.set(row.id, value)
-          }
-          queueFlush()
-        }}
-      />
+      <div className="grid gap-4 md:grid-cols-2">{sections}</div>
     </section>
   )
 }

--- a/apps/x-plan/components/sheets/product-setup-workspace.tsx
+++ b/apps/x-plan/components/sheets/product-setup-workspace.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import clsx from 'clsx'
+import type { ReactNode } from 'react'
+import { useId, useMemo, useState } from 'react'
+
+import { ProductSetupGrid } from '@/components/sheets/product-setup-grid'
+import {
+  ProductSetupParametersPanel,
+  type ProductSetupParametersPanelProps,
+} from '@/components/sheets/product-setup-panels'
+
+type ParameterList = ProductSetupParametersPanelProps['parameters']
+
+type ProductSetupWorkspaceProps = {
+  products: Array<{ id: string; sku: string; name: string }>
+  operationsParameters: ParameterList
+  salesParameters: ParameterList
+  financeParameters: ParameterList
+}
+
+type TabKey = 'catalogue' | 'operations' | 'sales' | 'finance'
+
+const TAB_CONFIG: Array<{
+  key: TabKey
+  label: string
+  subtitle: string
+  description: string
+}> = [
+  {
+    key: 'catalogue',
+    label: 'Catalogue',
+    subtitle: 'SKU roster',
+    description: 'Create, edit, or retire SKUs that power every downstream table.',
+  },
+  {
+    key: 'operations',
+    label: 'Operations',
+    subtitle: 'Supply defaults',
+    description: 'Set sourcing assumptions like production timelines and MOQ.',
+  },
+  {
+    key: 'sales',
+    label: 'Sales',
+    subtitle: 'Demand guardrails',
+    description: 'Tune warning thresholds and forecast fallbacks for planners.',
+  },
+  {
+    key: 'finance',
+    label: 'Finance',
+    subtitle: 'Cash levers',
+    description: 'Manage carrying costs, payment cadences, and target margins.',
+  },
+]
+
+const panelAccent =
+  'rounded-3xl border border-[#0b3a52] bg-[#041324] p-6 text-slate-100 shadow-[0_26px_55px_rgba(1,12,24,0.55)] ring-1 ring-[#0f2e45]/60 before:pointer-events-none before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_8%_18%,rgba(0,194,185,0.16),transparent_60%),radial-gradient(circle_at_92%_22%,rgba(0,194,185,0.08),transparent_60%)] before:opacity-90 before:mix-blend-screen before:content-[""] backdrop-blur-xl'
+
+export function ProductSetupWorkspace({
+  products,
+  operationsParameters,
+  salesParameters,
+  financeParameters,
+}: ProductSetupWorkspaceProps) {
+  const [activeTab, setActiveTab] = useState<TabKey>('catalogue')
+  const tablistId = useId()
+
+  const tabPanels = useMemo(() => {
+    return {
+      catalogue: (
+        <ProductSetupGrid
+          products={products}
+          className="!space-y-6"
+        />
+      ),
+      operations: (
+        <ProductSetupParametersPanel
+          title="Operations parameters"
+          description="Supply chain defaults applied to new products, POs, and lead calculations."
+          parameters={operationsParameters}
+        />
+      ),
+      sales: (
+        <ProductSetupParametersPanel
+          title="Sales parameters"
+          description="Demand heuristics that shape forecast smoothing and stock warnings."
+          parameters={salesParameters}
+        />
+      ),
+      finance: (
+        <ProductSetupParametersPanel
+          title="Finance parameters"
+          description="Cash flow assumptions used to project working capital and profitability."
+          parameters={financeParameters}
+        />
+      ),
+    } satisfies Record<TabKey, ReactNode>
+  }, [financeParameters, operationsParameters, products, salesParameters])
+
+  return (
+    <section className="space-y-6">
+      <header className={clsx('relative overflow-hidden', panelAccent)}>
+        <div className="relative flex flex-col gap-4">
+          <div className="space-y-2">
+            <p className="text-sm font-semibold uppercase tracking-[0.4em] text-cyan-300/80">Product setup</p>
+            <h1 className="text-3xl font-semibold text-white">Configure your launchpad</h1>
+            <p className="max-w-2xl text-sm leading-relaxed text-slate-200/80">
+              Keep every workbook tab aligned by curating catalogue data and business parameters from a single place. Switch between tables without losing context.
+            </p>
+          </div>
+          <div role="tablist" aria-label="Product setup sections" className="flex flex-wrap gap-2">
+            {TAB_CONFIG.map((tab) => {
+              const isActive = tab.key === activeTab
+              return (
+                <button
+                  key={tab.key}
+                  id={`${tablistId}-${tab.key}`}
+                  role="tab"
+                  type="button"
+                  aria-selected={isActive}
+                  aria-controls={`${tablistId}-${tab.key}-panel`}
+                  onClick={() => setActiveTab(tab.key)}
+                  className={clsx(
+                    'flex min-w-[160px] flex-1 items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/60 sm:flex-none',
+                    isActive
+                      ? 'border-[#00c2b9] bg-[#00c2b9]/15 text-cyan-100 shadow-[0_18px_40px_rgba(0,194,185,0.2)]'
+                      : 'border-white/12 bg-white/5 text-slate-200 hover:border-cyan-300/50 hover:text-cyan-100'
+                  )}
+                >
+                  <div className="space-y-0.5">
+                    <span className="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-300/80">{tab.subtitle}</span>
+                    <span className="block text-sm font-medium">{tab.label}</span>
+                  </div>
+                  <svg
+                    className={clsx('h-4 w-4 transition-transform', isActive ? 'text-cyan-100' : 'text-slate-300/80')}
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.6"
+                  >
+                    <path d="M9 18l6-6-6-6" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      </header>
+      {TAB_CONFIG.map((tab) => {
+        const isActive = tab.key === activeTab
+        return (
+          <div
+            key={tab.key}
+            id={`${tablistId}-${tab.key}-panel`}
+            role="tabpanel"
+            aria-labelledby={`${tablistId}-${tab.key}`}
+            hidden={!isActive}
+            className="animate-fade-in"
+          >
+            {isActive ? tabPanels[tab.key] : null}
+          </div>
+        )
+      })}
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- replace the product setup parameter Handsontable with a responsive card-based editor and modern styling
- add debounced autosave logic with field-level status feedback and numeric validation
- normalize numeric inputs after persistence so shared planners receive consistent formatting

## Testing
- pnpm --filter @ecom-os/x-plan lint

------
https://chatgpt.com/codex/tasks/task_e_68dabef70f288321a627de1846e8469d