### PR TITLE
fix(wms): correct NextAuth basePath to avoid double-prefixing

### DIFF
--- a/apps/wms/next.config.js
+++ b/apps/wms/next.config.js
@@ -17,8 +17,7 @@ const nextConfig = {
   // The webpack configuration below is ignored when using Turbopack (--turbo flag).
   // Base path configuration - set BASE_PATH env var if needed
   basePath,
-  assetPrefix: basePath || undefined,
-  
+
   // Fix for Next.js 15 module resolution and HMR issues
   transpilePackages: ['lucide-react'],
   

--- a/apps/wms/next.config.js
+++ b/apps/wms/next.config.js
@@ -9,12 +9,15 @@
 // Get version from package.json
 const { version } = require('./package.json')
 
+const basePath = process.env.BASE_PATH || ''
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Note: This config supports both Webpack (for production builds) and Turbopack (for development).
   // The webpack configuration below is ignored when using Turbopack (--turbo flag).
   // Base path configuration - set BASE_PATH env var if needed
-  basePath: process.env.BASE_PATH || '',
+  basePath,
+  assetPrefix: basePath || undefined,
   
   // Fix for Next.js 15 module resolution and HMR issues
   transpilePackages: ['lucide-react'],
@@ -91,16 +94,16 @@ const nextConfig = {
   },
 
   async rewrites() {
-    const basePath = process.env.BASE_PATH || process.env.NEXT_PUBLIC_BASE_PATH || ''
+    const rewriteBasePath = basePath || process.env.NEXT_PUBLIC_BASE_PATH || ''
 
-    if (!basePath) {
+    if (!rewriteBasePath) {
       return []
     }
 
     return [
       {
         source: '/api/:path*',
-        destination: `${basePath}/api/:path*`,
+        destination: `${rewriteBasePath}/api/:path*`,
       },
     ]
   },
@@ -110,6 +113,7 @@ const nextConfig = {
     NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000',
     NEXT_PUBLIC_BUILD_TIME: process.env.BUILD_TIME || new Date().toISOString(),
     NEXT_PUBLIC_VERSION: version,
+    NEXT_PUBLIC_BASE_PATH: process.env.NEXT_PUBLIC_BASE_PATH || basePath,
   },
   
   // Webpack configuration (for production builds)

--- a/apps/wms/src/app/layout.tsx
+++ b/apps/wms/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css'
 import Providers from '@/components/providers'
 import { Toaster } from 'react-hot-toast'
 import '@/lib/utils/patch-fetch'
+import FetchPatch from '@/components/fetch-patch'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -21,6 +22,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
+        <FetchPatch />
         <Providers>
           {children}
           <Toaster

--- a/apps/wms/src/components/fetch-patch.tsx
+++ b/apps/wms/src/components/fetch-patch.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import '@/lib/utils/patch-fetch'
+
+/**
+ * Patches global fetch in the browser so API calls respect the WMS base path.
+ */
+export function FetchPatch() {
+  return null
+}
+
+export default FetchPatch

--- a/apps/wms/src/lib/auth.ts
+++ b/apps/wms/src/lib/auth.ts
@@ -21,7 +21,10 @@ if (sharedSecret) {
   process.env.NEXTAUTH_SECRET = sharedSecret
 }
 
+const basePath = process.env.BASE_PATH || process.env.NEXT_PUBLIC_BASE_PATH || ''
+
 const baseAuthOptions: NextAuthOptions = {
+  basePath: basePath ? `${basePath}/api/auth` : '/api/auth',
   session: {
     strategy: 'jwt',
     maxAge: 30 * 24 * 60 * 60, // 30 days

--- a/apps/wms/src/lib/auth.ts
+++ b/apps/wms/src/lib/auth.ts
@@ -21,10 +21,11 @@ if (sharedSecret) {
   process.env.NEXTAUTH_SECRET = sharedSecret
 }
 
-const basePath = process.env.BASE_PATH || process.env.NEXT_PUBLIC_BASE_PATH || ''
-
 const baseAuthOptions: NextAuthOptions = {
-  basePath: basePath ? `${basePath}/api/auth` : '/api/auth',
+  // Note: NextAuth basePath should be '/api/auth' because Next.js basePath
+  // already handles the '/wms' prefix. Setting it to '/wms/api/auth' would
+  // create '/wms/wms/api/auth' due to double-prefixing.
+  basePath: '/api/auth',
   session: {
     strategy: 'jwt',
     maxAge: 30 * 24 * 60 * 60, // 30 days


### PR DESCRIPTION
## Problem
WMS NextAuth endpoints returning 404 errors causing redirect loops.

## Root Cause
- Next.js config has `basePath: '/wms'` which prefixes ALL routes
- NextAuth was configured with `basePath: '/wms/api/auth'`
- This caused double-prefixing: `/wms` + `/wms/api/auth` = `/wms/wms/api/auth`

## Solution
Set NextAuth `basePath: '/api/auth'` so Next.js applies the `/wms` prefix correctly, resulting in `/wms/api/auth`.

## Testing
After deployment, verify:
- `/wms/api/auth/session` returns JSON (not 404)
- `/wms/api/auth/providers` returns JSON
- WMS login works without redirect loops