### PR TITLE
fix(x-plan): use NEXTAUTH_URL for runtime base URL configuration

### DIFF
--- a/apps/x-plan/lib/auth.ts
+++ b/apps/x-plan/lib/auth.ts
@@ -1,8 +1,9 @@
 import type { NextAuthOptions } from 'next-auth'
 import { applyDevAuthDefaults, withSharedAuth } from '@ecom-os/auth'
 
+// Use NEXTAUTH_URL if available (runtime), otherwise fall back to NEXT_PUBLIC_APP_URL (build-time) or localhost
 const devPort = process.env.PORT || process.env.CROSS_PLAN_PORT || 3008
-const devBaseUrl = process.env.NEXT_PUBLIC_APP_URL || `http://localhost:${devPort}`
+const devBaseUrl = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_APP_URL || `http://localhost:${devPort}`
 const centralDev = process.env.CENTRAL_AUTH_URL || 'http://localhost:3000'
 
 applyDevAuthDefaults({


### PR DESCRIPTION
## Summary
- Fix x-plan redirect URLs using localhost instead of production domain
- Use NEXTAUTH_URL for runtime base URL configuration

## Problem
X-plan was redirecting to `localhost:3009` in production because `NEXT_PUBLIC_APP_URL` is baked into the Next.js build at compile time and cannot change at runtime.

## Solution  
Modified `apps/x-plan/lib/auth.ts` to prioritize `NEXTAUTH_URL` (runtime variable) over `NEXT_PUBLIC_APP_URL` (build-time variable) for the baseUrl configuration.

## Changes
- Updated devBaseUrl to check `process.env.NEXTAUTH_URL` first
- Falls back to `NEXT_PUBLIC_APP_URL` then `localhost:${port}` for development

## Deployment Notes
After merging, x-plan must be rebuilt and PM2 process configured with:
```
NEXTAUTH_URL=https://ecomos.targonglobal.com/xplan
PORT=3009
```

## Related
- Similar to WMS fix in PR #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)