### PR TITLE
fix(ci): skip deployment for docs-only changes

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -7,12 +7,32 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.filter.outputs.should_deploy }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Check for code changes
+        id: filter
+        run: |
+          # Skip deploy if only docs/workflow files changed
+          if git diff --name-only ${{ github.event.pull_request.base.sha || 'HEAD^' }} ${{ github.event.pull_request.head.sha || 'HEAD' }} | grep -qvE '^(BRANCHING\.md|\.github/workflows/(auto-sync-dev|pr-policy)\.yml|docs/|README\.md)'; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_deploy=false" >> $GITHUB_OUTPUT
+          fi
+
   deploy:
     runs-on: ubuntu-latest
+    needs: check-changes
     if: >-
-      ${{ github.event_name == 'workflow_dispatch' ||
+      ${{ needs.check-changes.outputs.should_deploy == 'true' &&
+          (github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'pull_request_target' &&
-           github.event.pull_request.head.ref == 'dev') }}
+           github.event.pull_request.head.ref == 'dev')) }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary
Adds change detection to deploy workflow to skip deployment when only documentation and workflow files are modified.

## Problem
PR #142 (syncing dev → main for branching docs) is failing deploy checks because it's trying to deploy documentation-only changes.

## Solution
Added a `check-changes` job that detects if only docs/workflow files changed:
- BRANCHING.md
- .github/workflows/(auto-sync-dev|pr-policy).yml
- docs/
- README.md

If only these files changed, the deploy job is skipped.

## Impact
- Prevents unnecessary deployment failures on docs-only PRs
- Allows PR #142 to pass checks and merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)