### PR TITLE
ci: wait for checks before auto-syncing dev

### DIFF
--- a/.github/workflows/auto-sync-dev.yml
+++ b/.github/workflows/auto-sync-dev.yml
@@ -16,6 +16,15 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Wait for required checks on merge commit
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          check-name: 'build-test'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          allowed-conclusions: success
+
       - name: Checkout main
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -49,11 +49,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: check-changes
-    if: >-
-      ${{ needs.check-changes.outputs.should_deploy == 'true' &&
-          (github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'pull_request_target' &&
-           github.event.pull_request.head.ref == 'dev')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' ||
+            (github.event_name == 'pull_request_target' &&
+             github.event.pull_request != null &&
+             github.event.pull_request.head.ref == 'dev' &&
+             needs.check-changes.outputs.should_deploy == 'true') }}
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## Summary
- pause the auto-sync workflow until the new merge commit finishes the required build-test check

## Testing
- pnpm lint --filter @ecom-os/wms -- --format=json (existing warnings only)
