### PR TITLE
infra(cd): fix CD deploy gating

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Check for code changes
         id: filter
         run: |
@@ -39,8 +39,15 @@ jobs:
             echo "Manual trigger - deploying"
             exit 0
           fi
+          BASE_COMMIT=${{ github.event.pull_request.base.sha || 'HEAD^' }}
+          HEAD_COMMIT=${{ github.event.pull_request.head.sha || 'HEAD' }}
+          if ! git rev-parse --verify "$BASE_COMMIT" >/dev/null 2>&1; then
+            echo "Missing base commit $BASE_COMMIT, defaulting to deploy"
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           # Skip deploy if only docs/workflow files changed
-          if git diff --name-only ${{ github.event.pull_request.base.sha || 'HEAD^' }} ${{ github.event.pull_request.head.sha || 'HEAD' }} | grep -qvE '^(BRANCHING\.md|\.github/workflows/(auto-sync-dev|pr-policy)\.yml|docs/|README\.md)'; then
+          if git diff --name-only "$BASE_COMMIT" "$HEAD_COMMIT" | grep -qvE '^(BRANCHING\.md|\.github/workflows/(auto-sync-dev|pr-policy)\.yml|docs/|README\.md)'; then
             echo "should_deploy=true" >> $GITHUB_OUTPUT
           else
             echo "should_deploy=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- fetch full history in CD check-changes job so base commit exists
- default to deploying when base commit can't be resolved to avoid false skips

## Testing
- gh workflow run CD --ref main (post-merge)