### PR TITLE
ci(cd): harden deployment workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         if: github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-${{ github.sha }}
+          name: build-artifacts-${{ github.event.pull_request.head.sha || github.sha }}
           path: |
             apps/website/.next
             apps/ecomos/.next

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -41,3 +42,7 @@ jobs:
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+
+      - name: Note Claude Code Review failure
+        if: steps.claude-review.outcome == 'failure'
+        run: echo "::warning title=Claude review unavailable::Claude Code review failed (rate limit or service issue); see workflow logs if you need details."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,8 +39,13 @@ jobs:
 
       - name: Run Claude Code
         id: claude
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
+
+      - name: Note Claude Code failure
+        if: steps.claude.outcome == 'failure'
+        run: echo "::warning title=Claude automation unavailable::Claude Code run failed (likely rate limit); check workflow logs for specifics."

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -358,7 +358,10 @@ jobs:
               exit 1
             fi
 
-            scan_output=$(ssh-keyscan -T 10 "$EC2_HOST" 2>/dev/null || true)
+            scan_output=$(ssh-keyscan -T 10 -t ed25519 "$EC2_HOST" 2>/dev/null || true)
+            if [ -z "$scan_output" ]; then
+              scan_output=$(ssh-keyscan -T 10 "$EC2_HOST" 2>/dev/null || true)
+            fi
             if [ -z "$scan_output" ]; then
               echo "::error title=Host key scan failed::Unable to retrieve SSH host key from $EC2_HOST." >&2
               exit 1
@@ -371,6 +374,7 @@ jobs:
             fi
 
             printf '%s\n' "$scan_output" > ~/.ssh/known_hosts
+            ssh-keygen -F "$EC2_HOST"
           fi
 
           chmod 644 ~/.ssh/known_hosts

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -314,7 +314,39 @@ jobs:
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
 
-          if [ -n "${EC2_HOST_PUBLIC_KEY:-}" ]; then
+          if [ -z "${EC2_HOST:-}" ]; then
+            echo "::error title=Missing EC2 host::EC2_HOST must be resolved before configuring known_hosts." >&2
+            exit 1
+          fi
+
+          resolved_entries=""
+
+          if [ -n "${EC2_HOST_FINGERPRINT:-}" ]; then
+            scan_output=$(ssh-keyscan -T 10 -t ed25519 "$EC2_HOST" 2>/dev/null || true)
+            if [ -z "$scan_output" ]; then
+              scan_output=$(ssh-keyscan -T 10 "$EC2_HOST" 2>/dev/null || true)
+            fi
+
+            if [ -n "$scan_output" ]; then
+              while IFS= read -r line; do
+                [ -z "$line" ] && continue
+                fp=$(printf '%s\n' "$line" | ssh-keygen -lf - | awk 'NR==1 {print $2}')
+                if [ "$fp" = "$EC2_HOST_FINGERPRINT" ]; then
+                  echo "Matched host key type: $(printf '%s\n' "$line" | awk '{print $2}')"
+                  host_token=$(printf '%s\n' "$line" | awk '{print $1}')
+                  rest=$(printf '%s\n' "$line" | cut -d' ' -f2-)
+                  if [ "$host_token" != "$EC2_HOST" ]; then
+                    line="$EC2_HOST $rest"
+                  fi
+                  resolved_entries+="$line\n"
+                fi
+              done <<EOF
+$scan_output
+EOF
+            fi
+          fi
+
+          if [ -z "$resolved_entries" ] && [ -n "${EC2_HOST_PUBLIC_KEY:-}" ]; then
             key_line="$EC2_HOST_PUBLIC_KEY"
             IFS=' ' read -r provided_host provided_type provided_key provided_rest <<<"$key_line"
 
@@ -324,17 +356,11 @@ jobs:
             fi
 
             target_host="${EC2_HOST:-$provided_host}"
-            if [ -z "${target_host:-}" ]; then
-              echo "::error title=Missing EC2 host::EC2_HOST must be resolved before configuring known_hosts." >&2
-              exit 1
-            fi
 
             formatted="$target_host $provided_type $provided_key"
             if [ -n "${provided_rest:-}" ]; then
               formatted="$formatted $provided_rest"
             fi
-
-            printf '%s\n' "$formatted" > ~/.ssh/known_hosts
 
             if [ -n "${EC2_HOST_FINGERPRINT:-}" ]; then
               derived_fingerprint=$(printf '%s\n' "$formatted" | ssh-keygen -lf - | awk 'NR==1 {print $2}')
@@ -344,42 +370,22 @@ jobs:
               fi
             fi
 
+            resolved_entries+="$formatted\n"
+
             if [ "$target_host" != "$provided_host" ] && [ -n "$provided_host" ] && [ "${provided_host#|}" = "$provided_host" ]; then
-              printf '%s\n' "$key_line" >> ~/.ssh/known_hosts
+              resolved_entries+="$key_line\n"
             fi
-          else
-            if [ -z "${EC2_HOST_FINGERPRINT:-}" ]; then
-              echo "::error title=Missing host verification data::Set EC2_HOST_PUBLIC_KEY or EC2_HOST_FINGERPRINT secret to verify the SSH host key." >&2
-              exit 1
-            fi
-
-            if [ -z "${EC2_HOST:-}" ]; then
-              echo "::error title=Missing EC2 host::EC2_HOST must be resolved before configuring known_hosts." >&2
-              exit 1
-            fi
-
-            scan_output=$(ssh-keyscan -T 10 -t ed25519 "$EC2_HOST" 2>/dev/null || true)
-            if [ -z "$scan_output" ]; then
-              scan_output=$(ssh-keyscan -T 10 "$EC2_HOST" 2>/dev/null || true)
-            fi
-            if [ -z "$scan_output" ]; then
-              echo "::error title=Host key scan failed::Unable to retrieve SSH host key from $EC2_HOST." >&2
-              exit 1
-            fi
-
-            key_types=$(printf '%s\n' "$scan_output" | awk '{print $2}' | paste -sd ',' -)
-            echo "Key types retrieved: ${key_types:-unknown}"
-
-            scan_fingerprint=$(printf '%s\n' "$scan_output" | ssh-keygen -lf - | awk 'NR==1 {print $2}')
-            if [ "$scan_fingerprint" != "$EC2_HOST_FINGERPRINT" ]; then
-              echo "::error title=Fingerprint mismatch::Expected $EC2_HOST_FINGERPRINT but found $scan_fingerprint for $EC2_HOST." >&2
-              exit 1
-            fi
-
-            printf '%s\n' "$scan_output" > ~/.ssh/known_hosts
-            echo "Known hosts after scan:"
-            ssh-keygen -lf ~/.ssh/known_hosts
           fi
+
+          if [ -z "$resolved_entries" ]; then
+            echo "::error title=Unable to resolve host key::Provide EC2_HOST_PUBLIC_KEY/EC2_HOST_FINGERPRINT or ensure ssh-keyscan succeeds." >&2
+            exit 1
+          fi
+
+          printf '%b' "$resolved_entries" > ~/.ssh/known_hosts
+
+          echo "Recorded host keys:"
+          ssh-keygen -lf ~/.ssh/known_hosts
 
           chmod 644 ~/.ssh/known_hosts
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -201,13 +201,13 @@ jobs:
           path: artifacts
 
       - name: Restore build outputs from artifacts
-        if: needs.prepare.outputs.artifact_run_id != '' && steps.download.conclusion == 'success'
+        if: needs.prepare.outputs.artifact_run_id != '' && steps.download.outcome == 'success'
         run: |
           set -euo pipefail
           rsync -a artifacts/build-artifacts-${{ needs.prepare.outputs.target_sha }}/ ./
 
       - name: Generate Prisma clients and build (fallback)
-        if: needs.prepare.outputs.artifact_run_id == '' || steps.download.conclusion != 'success'
+        if: needs.prepare.outputs.artifact_run_id == '' || steps.download.outcome != 'success'
         run: |
           pnpm --filter @ecom-os/auth prisma:generate
           pnpm --filter @ecom-os/wms db:generate
@@ -284,20 +284,26 @@ jobs:
           fi
 
       - name: Generate and inject CI SSH key via EC2 Instance Connect
-        if: ${{ env.AWS_ROLE_TO_ASSUME != '' && env.AWS_REGION != '' }}
+        if: ${{ github.event_name == 'workflow_run' && env.AWS_ROLE_TO_ASSUME != '' && env.AWS_REGION != '' && env.EIC_INSTANCE_ID != '' }}
+        continue-on-error: true
         env:
           OS_USER: ${{ env.EC2_USER_SECRET }}
         run: |
-          set -e
           OS_USER=${OS_USER:-ubuntu}
           ssh-keygen -t ed25519 -N '' -f ~/.ssh/ci_key -C ci@github || true
-          aws ec2-instance-connect send-ssh-public-key \
+          if ! aws ec2-instance-connect send-ssh-public-key \
             --instance-id "$EIC_INSTANCE_ID" \
             --availability-zone "$EIC_INSTANCE_AZ" \
             --instance-os-user "$OS_USER" \
-            --ssh-public-key "file://$HOME/.ssh/ci_key.pub"
-          ssh -i ~/.ssh/ci_key "$OS_USER@$EC2_HOST" \
-            "mkdir -p ~/.ssh && touch ~/.ssh/authorized_keys && grep -qxF '$(cat ~/.ssh/ci_key.pub)' ~/.ssh/authorized_keys || echo '$(cat ~/.ssh/ci_key.pub)' >> ~/.ssh/authorized_keys && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys"
+            --ssh-public-key "file://$HOME/.ssh/ci_key.pub"; then
+            echo "::warning title=EIC key injection failed::Continuing with existing SSH credentials" >&2
+            exit 0
+          fi
+          if ! ssh -i ~/.ssh/ci_key "$OS_USER@$EC2_HOST" \
+            "mkdir -p ~/.ssh && touch ~/.ssh/authorized_keys && grep -qxF '$(cat ~/.ssh/ci_key.pub)' ~/.ssh/authorized_keys || echo '$(cat ~/.ssh/ci_key.pub)' >> ~/.ssh/authorized_keys && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys"; then
+            echo "::warning title=EIC SSH propagation failed::Continuing with existing SSH credentials" >&2
+            exit 0
+          fi
           install -m 600 -D ~/.ssh/ci_key ~/.ssh/id_rsa
 
       - name: Configure known_hosts entry

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -367,6 +367,9 @@ jobs:
               exit 1
             fi
 
+            key_types=$(printf '%s\n' "$scan_output" | awk '{print $2}' | paste -sd ',' -)
+            echo "Key types retrieved: ${key_types:-unknown}"
+
             scan_fingerprint=$(printf '%s\n' "$scan_output" | ssh-keygen -lf - | awk 'NR==1 {print $2}')
             if [ "$scan_fingerprint" != "$EC2_HOST_FINGERPRINT" ]; then
               echo "::error title=Fingerprint mismatch::Expected $EC2_HOST_FINGERPRINT but found $scan_fingerprint for $EC2_HOST." >&2
@@ -374,7 +377,8 @@ jobs:
             fi
 
             printf '%s\n' "$scan_output" > ~/.ssh/known_hosts
-            ssh-keygen -F "$EC2_HOST"
+            echo "Known hosts after scan:"
+            ssh-keygen -lf ~/.ssh/known_hosts
           fi
 
           chmod 644 ~/.ssh/known_hosts

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -201,13 +201,15 @@ jobs:
           path: artifacts
 
       - name: Restore build outputs from artifacts
-        if: needs.prepare.outputs.artifact_run_id != '' && steps.download.outcome == 'success'
+        if: needs.prepare.outputs.artifact_run_id != '' && steps.download.outputs.download-path != ''
         run: |
           set -euo pipefail
-          rsync -a artifacts/build-artifacts-${{ needs.prepare.outputs.target_sha }}/ ./
+          ARTIFACT_ROOT="${{ steps.download.outputs.download-path }}"
+          TARGET_SHA="${{ needs.prepare.outputs.target_sha }}"
+          rsync -a "${ARTIFACT_ROOT}/build-artifacts-${TARGET_SHA}/" ./
 
       - name: Generate Prisma clients and build (fallback)
-        if: needs.prepare.outputs.artifact_run_id == '' || steps.download.outcome != 'success'
+        if: needs.prepare.outputs.artifact_run_id == '' || steps.download.outputs.download-path == ''
         run: |
           pnpm --filter @ecom-os/auth prisma:generate
           pnpm --filter @ecom-os/wms db:generate
@@ -313,7 +315,38 @@ jobs:
           chmod 700 ~/.ssh
 
           if [ -n "${EC2_HOST_PUBLIC_KEY:-}" ]; then
-            printf '%s\n' "$EC2_HOST_PUBLIC_KEY" > ~/.ssh/known_hosts
+            key_line="$EC2_HOST_PUBLIC_KEY"
+            IFS=' ' read -r provided_host provided_type provided_key provided_rest <<<"$key_line"
+
+            if [ -z "${provided_type:-}" ] || [ -z "${provided_key:-}" ]; then
+              echo "::error title=Invalid host key::EC2_HOST_PUBLIC_KEY must contain a host, key type, and key material." >&2
+              exit 1
+            fi
+
+            target_host="${EC2_HOST:-$provided_host}"
+            if [ -z "${target_host:-}" ]; then
+              echo "::error title=Missing EC2 host::EC2_HOST must be resolved before configuring known_hosts." >&2
+              exit 1
+            fi
+
+            formatted="$target_host $provided_type $provided_key"
+            if [ -n "${provided_rest:-}" ]; then
+              formatted="$formatted $provided_rest"
+            fi
+
+            printf '%s\n' "$formatted" > ~/.ssh/known_hosts
+
+            if [ -n "${EC2_HOST_FINGERPRINT:-}" ]; then
+              derived_fingerprint=$(printf '%s\n' "$formatted" | ssh-keygen -lf - | awk 'NR==1 {print $2}')
+              if [ "$derived_fingerprint" != "$EC2_HOST_FINGERPRINT" ]; then
+                echo "::error title=Fingerprint mismatch::Expected $EC2_HOST_FINGERPRINT but derived $derived_fingerprint from EC2_HOST_PUBLIC_KEY." >&2
+                exit 1
+              fi
+            fi
+
+            if [ "$target_host" != "$provided_host" ] && [ -n "$provided_host" ] && [ "${provided_host#|}" = "$provided_host" ]; then
+              printf '%s\n' "$key_line" >> ~/.ssh/known_hosts
+            fi
           else
             if [ -z "${EC2_HOST_FINGERPRINT:-}" ]; then
               echo "::error title=Missing host verification data::Set EC2_HOST_PUBLIC_KEY or EC2_HOST_FINGERPRINT secret to verify the SSH host key." >&2


### PR DESCRIPTION
## Summary
- switch CI artifact naming to PR head SHA so CD can fetch builds
- adjust CD to reuse artifacts only when they download successfully
- derive the SSH host key via ssh-keyscan when fingerprint is provided to avoid known_hosts drift
- allow Claude automation to fail gracefully without breaking guard workflows

## Testing
- gh run view 18300507638 --json status,conclusion
- gh run view 18300507392 --log-failed
