### PR TITLE
infra(cd): guard workflow_run id lookup

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -134,13 +134,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
-          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id || '' }}
+          EVENT_PATH: ${{ github.event_path }}
           TARGET_SHA: ${{ steps.context.outputs.target_sha }}
           REPOSITORY: ${{ github.repository }}
+          TRIGGER_KIND: ${{ steps.context.outputs.trigger }}
         run: |
           set -euo pipefail
 
-          if [ "$EVENT_NAME" = "workflow_run" ] && [ -n "$WORKFLOW_RUN_ID" ]; then
+          WORKFLOW_RUN_ID=$(jq -r '.workflow_run.id // ""' "$EVENT_PATH")
+
+          if [ "$TRIGGER_KIND" = "workflow_run" ] && [ -n "$WORKFLOW_RUN_ID" ]; then
             echo "artifact_run_id=$WORKFLOW_RUN_ID" >> $GITHUB_OUTPUT
             exit 0
           fi


### PR DESCRIPTION
Read workflow_run.id via jq in the artifact resolver so push validation runs stop aborting.