### PR TITLE
infra(cd): skip prepare on push

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -28,6 +28,7 @@ jobs:
         run: echo "Push validation run acknowledged"
 
   prepare:
+    if: ${{ github.event_name != 'push' }}
     runs-on: ubuntu-latest
     outputs:
       target_sha: ${{ steps.context.outputs.target_sha }}


### PR DESCRIPTION
Exclude the heavy prepare job when GitHub runs push-only validation so the workflow evaluates cleanly.