### PR TITLE
infra(main): skip prepare on push

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -28,6 +28,7 @@ jobs:
         run: echo "Push validation run acknowledged"
 
   prepare:
+    if: ${{ github.event_name != 'push' }}
     runs-on: ubuntu-latest
     outputs:
       target_sha: ${{ steps.context.outputs.target_sha }}


### PR DESCRIPTION
Skip the heavy prepare job on GitHub's push validation runs to stop the zero-second failures.