### PR TITLE
infra(main): allow prepare on push

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -28,7 +28,6 @@ jobs:
         run: echo "Push validation run acknowledged"
 
   prepare:
-    if: ${{ github.event_name != 'push' }}
     runs-on: ubuntu-latest
     outputs:
       target_sha: ${{ steps.context.outputs.target_sha }}


### PR DESCRIPTION
Remove the push guard so CD prepare runs even during GitHub validation.