### PR TITLE
ci(cd): always deploy on manual trigger

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-changes
     if: >-
-      ${{ needs.check-changes.outputs.should_deploy == 'true' &&
-          (github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'pull_request_target' &&
-           github.event.pull_request.head.ref == 'dev')) }}
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (needs.check-changes.outputs.should_deploy == 'true' &&
+           github.event_name == 'pull_request_target' &&
+           github.event.pull_request.head.ref == 'dev') }}
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## Summary
- ensure manual CD runs the deploy stage even when artifacts are missing

## Testing
- gh workflow run CI --ref infra/cd-manual-deploy