### PR TITLE
ci(cd): re-enable CI-triggered deploys

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types: [completed]
 
 jobs:
   wait-for-ci:
@@ -28,19 +32,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 2
       - name: Check for code changes
         id: filter
         run: |
-          # For manual triggers (workflow_dispatch), always deploy
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          EVENT="${{ github.event_name }}"
+
+          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_run" ]; then
             echo "should_deploy=true" >> $GITHUB_OUTPUT
-            echo "Manual trigger - deploying"
+            if [ "$EVENT" = "workflow_dispatch" ]; then
+              echo "Manual trigger - deploying"
+            else
+              echo "CI workflow completed on main; deploying"
+            fi
             exit 0
           fi
           # Skip deploy if only docs/workflow files changed
-          if git diff --name-only ${{ github.event.pull_request.base.sha || 'HEAD^' }} ${{ github.event.pull_request.head.sha || 'HEAD' }} | grep -qvE '^(BRANCHING\.md|\.github/workflows/(auto-sync-dev|pr-policy)\.yml|docs/|README\.md)'; then
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -qvE '^(BRANCHING\.md|\.github/workflows/(auto-sync-dev|pr-policy)\.yml|docs/|README\.md)'; then
             echo "should_deploy=true" >> $GITHUB_OUTPUT
           else
             echo "should_deploy=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- run deploy job when main CI finishes successfully
- fallback to manual and PR checks using existing guard

## Testing
- gh workflow run CI --ref infra/cd-workflow-run