### PR TITLE
ci(cd): harden deploy diff detection

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Check for code changes
         id: filter
         run: |
@@ -49,7 +49,13 @@ jobs:
             exit 0
           fi
           # Skip deploy if only docs/workflow files changed
-          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -qvE '^(BRANCHING\.md|\.github/workflows/(auto-sync-dev|pr-policy)\.yml|docs/|README\.md)'; then
+          if ! git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > changed-files.txt; then
+            echo "Diff calculation failed; deploying to be safe" >&2
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          if grep -qvE '^(BRANCHING\.md|\.github/workflows/(auto-sync-dev|pr-policy)\.yml|docs/|README\.md)' changed-files.txt; then
             echo "should_deploy=true" >> $GITHUB_OUTPUT
           else
             echo "should_deploy=false" >> $GITHUB_OUTPUT
@@ -60,6 +66,7 @@ jobs:
     needs: check-changes
     if: >-
       ${{ github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'workflow_run' ||
           (needs.check-changes.outputs.should_deploy == 'true' &&
            github.event_name == 'pull_request_target' &&
            github.event.pull_request.head.ref == 'dev') }}
@@ -83,7 +90,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 0
       - name: Install tools (ansible, rsync, jq, curl)
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary
- fetch full history before diffing pull_request_target
- treat diff failures as deploy-true and emit changed files for debugging
- allow workflow_run event through deploy gate