### PR TITLE
ci(cd): trust host key before ssh injection

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -195,26 +195,6 @@ jobs:
             exit 1
           fi
 
-      - name: Generate and inject CI SSH key via EC2 Instance Connect
-        if: ${{ env.AWS_ROLE_TO_ASSUME != '' && env.AWS_REGION != '' }}
-        env:
-          OS_USER: ${{ env.EC2_USER_SECRET }}
-        run: |
-          set -e
-          OS_USER=${OS_USER:-ubuntu}
-          ssh-keygen -t ed25519 -N '' -f ~/.ssh/ci_key -C ci@github || true
-          # Push key via EIC (ephemeral)
-          aws ec2-instance-connect send-ssh-public-key \
-            --instance-id "$EIC_INSTANCE_ID" \
-            --availability-zone "$EIC_INSTANCE_AZ" \
-            --instance-os-user "$OS_USER" \
-            --ssh-public-key "file://$HOME/.ssh/ci_key.pub"
-          # Use ephemeral window to append pubkey permanently
-          ssh -i ~/.ssh/ci_key "$OS_USER@$EC2_HOST" \
-            "mkdir -p ~/.ssh && touch ~/.ssh/authorized_keys && grep -qxF '$(cat ~/.ssh/ci_key.pub)' ~/.ssh/authorized_keys || echo '$(cat ~/.ssh/ci_key.pub)' >> ~/.ssh/authorized_keys && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys"
-          # Switch default key for subsequent steps
-          install -m 600 -D ~/.ssh/ci_key ~/.ssh/id_rsa
-
       - name: Configure known_hosts entry
         run: |
           set -euo pipefail
@@ -244,6 +224,26 @@ jobs:
           fi
 
           chmod 644 ~/.ssh/known_hosts
+
+      - name: Generate and inject CI SSH key via EC2 Instance Connect
+        if: ${{ env.AWS_ROLE_TO_ASSUME != '' && env.AWS_REGION != '' }}
+        env:
+          OS_USER: ${{ env.EC2_USER_SECRET }}
+        run: |
+          set -e
+          OS_USER=${OS_USER:-ubuntu}
+          ssh-keygen -t ed25519 -N '' -f ~/.ssh/ci_key -C ci@github || true
+          # Push key via EIC (ephemeral)
+          aws ec2-instance-connect send-ssh-public-key \
+            --instance-id "$EIC_INSTANCE_ID" \
+            --availability-zone "$EIC_INSTANCE_AZ" \
+            --instance-os-user "$OS_USER" \
+            --ssh-public-key "file://$HOME/.ssh/ci_key.pub"
+          # Use ephemeral window to append pubkey permanently
+          ssh -i ~/.ssh/ci_key "$OS_USER@$EC2_HOST" \
+            "mkdir -p ~/.ssh && touch ~/.ssh/authorized_keys && grep -qxF '$(cat ~/.ssh/ci_key.pub)' ~/.ssh/authorized_keys || echo '$(cat ~/.ssh/ci_key.pub)' >> ~/.ssh/authorized_keys && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys"
+          # Switch default key for subsequent steps
+          install -m 600 -D ~/.ssh/ci_key ~/.ssh/id_rsa
 
       - name: Check remote disk usage before deploy
         continue-on-error: true


### PR DESCRIPTION
## Summary
- configure known_hosts before attempting the EC2 Instance Connect ssh hop
- avoid host key verification failure when the runner has no cached fingerprint